### PR TITLE
Support constructor params for agents 

### DIFF
--- a/agentic/src/agent.rs
+++ b/agentic/src/agent.rs
@@ -24,7 +24,6 @@ use golem_wasm_rpc::WitValue;
 //  ```
 // There is no need to implement `Agent` anywhere, as it is automatically implemented by the `[agent_implementation]` attribute.
 pub trait Agent: Send + Sync {
-    // During implementation it should be possible to use DataValue for multi modal types
     fn invoke(&self, method_name: String, input: Vec<WitValue>) -> StatusUpdate;
     fn get_definition(&self) -> AgentType;
 }

--- a/agentic/src/agent_construct.rs
+++ b/agentic/src/agent_construct.rs
@@ -1,0 +1,3 @@
+pub trait AgentConstruct: Sized {
+    fn construct_from_params(params: Vec<golem_wasm_rpc::WitValue>, agent_id: String) -> Self;
+}

--- a/agentic/src/agent_construct.rs
+++ b/agentic/src/agent_construct.rs
@@ -1,3 +1,6 @@
+use golem_wasm_rpc::WitType;
+
 pub trait AgentConstruct: Sized {
     fn construct_from_params(params: Vec<golem_wasm_rpc::WitValue>, agent_id: String) -> Self;
+    fn get_params() -> Vec<(String, WitType)>;
 }

--- a/agentic/src/agent_registry.rs
+++ b/agentic/src/agent_registry.rs
@@ -1,11 +1,11 @@
 use crate::agent_instance_registry::AgentName;
-use crate::bindings::exports::golem::agent::guest::{AgentRef, AgentType};
+use crate::bindings::exports::golem::agent::guest::{AgentRef, AgentType, WitValue};
 use crate::ResolvedAgent;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-type AgentTraitName = String;
+type AgentTypeName = String;
 
 #[derive(Hash, PartialEq, Eq)]
 pub struct AgentId(pub String);
@@ -16,7 +16,7 @@ pub struct AgentRefInternal {
     agent_name: String,
 }
 
-static AGENT_DEF_REGISTRY: Lazy<Mutex<HashMap<AgentTraitName, AgentType>>> =
+static AGENT_DEF_REGISTRY: Lazy<Mutex<HashMap<AgentTypeName, AgentType>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 // Given an agent name, we can register an impl of agent-initiator
@@ -115,7 +115,7 @@ pub fn get_all_agent_definitions() -> Vec<AgentType> {
 }
 
 pub fn get_agent_initiator(
-    agent_trait_name: AgentTraitName,
+    agent_trait_name: AgentTypeName,
 ) -> Option<Arc<dyn AgentInitiator + Send + Sync>> {
     AGENT_INITIATOR_REGISTRY
         .lock()
@@ -125,5 +125,5 @@ pub fn get_agent_initiator(
 }
 
 pub trait AgentInitiator: Send + Sync {
-    fn initiate(&self) -> ResolvedAgent;
+    fn initiate(&self, params: Vec<WitValue>) -> ResolvedAgent;
 }

--- a/agentic/src/agent_registry.rs
+++ b/agentic/src/agent_registry.rs
@@ -4,11 +4,34 @@ use crate::ResolvedAgent;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use crate::bindings::golem::agent::common::{AgentDependency, AgentMethod, AgentConstructor};
 
 type AgentTypeName = String;
 
 #[derive(Hash, PartialEq, Eq)]
 pub struct AgentId(pub String);
+
+// An agent-type which is devoid of a few details from what's in WIT
+
+#[derive(Clone)]
+pub struct GenericAgentType {
+    pub type_name: String,
+    pub description: String,
+    pub methods: Vec<AgentMethod>,
+    pub requires: Vec<AgentDependency>
+}
+
+impl GenericAgentType {
+    pub fn to_agent_type(&self, agent_constructor: AgentConstructor) -> AgentType {
+        AgentType {
+            type_name: self.type_name.clone(),
+            description: self.description.clone(),
+            agent_constructor: agent_constructor,
+            methods: self.methods.clone(),
+            requires: self.requires.clone(),
+        }
+    }
+}
 
 pub struct AgentRefInternal {
     inner_instance: crate::bindings::exports::golem::agent::guest::Agent,
@@ -16,7 +39,10 @@ pub struct AgentRefInternal {
     agent_name: String,
 }
 
-static AGENT_DEF_REGISTRY: Lazy<Mutex<HashMap<AgentTypeName, AgentType>>> =
+static GENERIC_AGENT_TYPE_REGISTRY: Lazy<Mutex<HashMap<AgentTypeName, GenericAgentType>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+static AGENT_TYPE_REGISTRY: Lazy<Mutex<HashMap<AgentTypeName, AgentType>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 // Given an agent name, we can register an impl of agent-initiator
@@ -30,7 +56,27 @@ static AGENT_INSTANCE_REGISTRY: Lazy<Mutex<HashMap<AgentId, AgentRefInternal>>> 
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 pub fn register_agent_definition(agent_trait_name: String, def: AgentType) {
-    AGENT_DEF_REGISTRY
+    AGENT_TYPE_REGISTRY
+        .lock()
+        .unwrap()
+        .insert(agent_trait_name, def);
+}
+
+pub fn register_generic_agent_type(
+    agent_trait_name: String,
+    def: GenericAgentType,
+) {
+    GENERIC_AGENT_TYPE_REGISTRY
+        .lock()
+        .unwrap()
+        .insert(agent_trait_name, def);
+}
+
+pub fn register_agent_type(
+    agent_trait_name: String,
+    def: AgentType,
+) {
+    AGENT_TYPE_REGISTRY
         .lock()
         .unwrap()
         .insert(agent_trait_name, def);
@@ -98,7 +144,17 @@ pub fn get_agent_instance(agent_id: AgentId) -> Option<AgentRef> {
 }
 
 pub fn get_agent_def_by_name(agent_trait_name: &str) -> Option<AgentType> {
-    AGENT_DEF_REGISTRY
+    AGENT_TYPE_REGISTRY
+        .lock()
+        .unwrap()
+        .get(agent_trait_name)
+        .cloned()
+}
+
+pub fn get_generic_agent_type_by_name(
+    agent_trait_name: &str,
+) -> Option<GenericAgentType> {
+    GENERIC_AGENT_TYPE_REGISTRY
         .lock()
         .unwrap()
         .get(agent_trait_name)
@@ -106,7 +162,7 @@ pub fn get_agent_def_by_name(agent_trait_name: &str) -> Option<AgentType> {
 }
 
 pub fn get_all_agent_definitions() -> Vec<AgentType> {
-    AGENT_DEF_REGISTRY
+    AGENT_TYPE_REGISTRY
         .lock()
         .unwrap()
         .values()

--- a/agentic/src/lib.rs
+++ b/agentic/src/lib.rs
@@ -5,12 +5,14 @@ use crate::bindings::golem::api::host;
 use golem_wasm_rpc::WitValue;
 
 pub use type_mapping::*;
+pub use agent_construct::*;
 
 pub mod agent;
 pub mod agent_instance_registry;
 pub mod agent_registry;
 pub mod bindings;
 mod type_mapping;
+mod agent_construct;
 
 #[derive(Clone)]
 pub struct ResolvedAgent {
@@ -71,7 +73,7 @@ impl Guest for Component {
 }
 
 impl GuestAgent for ResolvedAgent {
-    fn new(agent_type: String) -> ResolvedAgent {
+    fn new(agent_type: String, params: Vec<golem_wasm_rpc::WitValue>) -> ResolvedAgent {
         let agent_types = agent_registry::get_all_agent_definitions();
 
         let agent_type = agent_types
@@ -93,7 +95,7 @@ impl GuestAgent for ResolvedAgent {
         let agent_initiator = agent_registry::get_agent_initiator(agent_type.type_name.clone());
 
         if let Some(agent) = agent_initiator {
-            let agent = agent.initiate();
+            let agent = agent.initiate(params);
             agent
         } else {
             panic!(

--- a/agentic/src/type_mapping.rs
+++ b/agentic/src/type_mapping.rs
@@ -2,6 +2,7 @@ use golem_wasm_ast::analysis::analysed_type::{str, u32, u64};
 use golem_wasm_ast::analysis::AnalysedType;
 use golem_wasm_rpc::{NodeBuilder, WitValue};
 use golem_wasm_rpc::{Value, WitType};
+use crate::agent::Agent;
 
 pub trait AgentArg: ToValue + FromWitValue + ToWitType {
     fn to_value(&self) -> golem_wasm_rpc::Value {
@@ -28,6 +29,7 @@ impl<T: ToValue + FromWitValue + ToWitType> AgentArg for T {}
 pub trait ToValue {
     fn to_value(&self) -> golem_wasm_rpc::Value;
 }
+
 
 pub trait FromValue {
     fn from_value(value: golem_wasm_rpc::Value) -> Result<Self, String>

--- a/agentic/wit/deps/golem-agent/common.wit
+++ b/agentic/wit/deps/golem-agent/common.wit
@@ -6,8 +6,16 @@ interface common {
     record agent-type {
         type-name:  string,
         description: string,
+        agent-constructor: agent-constructor,
         methods:     list<agent-method>,
         requires:    list<agent-dependency>,
+    }
+
+    record agent-constructor {
+        name:          option<string>,
+        description:   string,
+        prompt-hint:   option<string>,
+        input-schema:  data-schema,
     }
 
     record agent-dependency {

--- a/agentic/wit/deps/golem-agent/guest.wit
+++ b/agentic/wit/deps/golem-agent/guest.wit
@@ -12,7 +12,7 @@ interface guest {
     }
 
     resource agent {
-        constructor(agent-name: string);
+        constructor(agent-name: string, params: list<wit-value>);
 
         get-id: func() -> string;
 


### PR DESCRIPTION
* anything with AgentArg instance can be part of the constructor params
* A struct that has already got an instance of `Agent` (meaning its another agent impl) automatically has an AgentArg instance
* Hence you can pass an agent to another agent with this!



Here is , discover-agent-types emitting the constructor params

```rust
>>> let x = instance();
>>> x.discover-agent-types()
>>> [
  {
    type-name: "assistant-agent",
    description: "",
    agent-constructor: {
      name: none,
      description: "",
      prompt-hint: none,
      input-schema: structured({
        parameters: [
          wit({
            nodes: [
              prim-string-type
            ]
          }),
          wit({
            nodes: [
              prim-u64-type
            ]
          }),
          wit({
            nodes: [
              prim-u32-type
            ]
          }),
          wit({
            nodes: [
              record-type([
                ("data",
                1),
                ("value",
                2)
              ]),
              prim-string-type,
              prim-u32-type
            ]
          })
        ]
      })
    },
    methods: [
      {
        name: "ask",
        description: "",
        prompt-hint: none,
        input-schema: structured({
          parameters: [
            wit({
              nodes: [
                prim-string-type
              ]
            }),
            wit({
              nodes: [
                prim-u64-type
              ]
            }),
            wit({
              nodes: [
                prim-u32-type
              ]
            }),
            wit({
              nodes: [
                record-type([
                  ("data",
                  1),
                  ("value",
                  2)
                ]),
                prim-string-type,
                prim-u32-type
              ]
            })
          ]
        }),
        output-schema: structured({
          parameters: [
            wit({
              nodes: [
                prim-string-type
              ]
            })
          ]
        })
      }
    ],
    requires: []
  }
]


```


Here is the wrapper component wit file updated in the examples:

```rust

package golem:simulated-agentic;

interface simulated-agent {
    use golem:agent/common.{status-update};

    // this should be generated based on the wit-type that exist in
    // agent-type that can be listed in raw component
    //  wit({
    //    nodes: [
    //      record-type([
    //        ("data",
    //        1),
    //        ("value",
    //        2)
    //      ]),
    //      prim-string-type,
    //      prim-u32-type
    //    ]
    //  })
    // may be prefix with agent name to avoid conflicts hence `assistant-agent-record1`
    record assistant-agent-record1 {
        data: string,
        value: u32,
    }

    // The assistant agent takes another record type too, and should be generated
    // based on agent definitions
    record assistant-agent-record2 {
        data: string,
        value: u32,
    }

    resource assistant-agent {
        // constructor parameters are derivable from `list-agent-type` similar to
        // how method parameters are derived
        // Example: {
        //     type-name: "assistant-agent",
        //     description: "",
        //     agent-constructor: {
        //       name: none,
        //       description: "",
        //       prompt-hint: none,
        //       input-schema: structured({
        //         parameters: [
        //           wit({
        //             nodes: [
        //               prim-string-type
        //             ]
        //           }),
        //           wit({
        //             nodes: [
        //               prim-u64-type
        //             ]
        //           }),
        //           wit({
        //             nodes: [
        //               prim-u32-type
        //             ]
        //           }),
        //           wit({
        //             nodes: [
        //               record-type([
        //                 ("data",
        //                 1),
        //                 ("value",
        //                 2)
        //               ]),
        //               prim-string-type,
        //               prim-u32-type
        //             ]
        //           })
        //         ]
        //       })
        //     },
        constructor(a: string, b: u64, c: u32, d: assistant-agent-record2);

        ask: func(param1: string, param2: u64, param3: u32, param4: assistant-agent-record1) -> status-update;
    }

    resource weather-agent {
        constructor();

        get-weather: func(param: string) -> status-update;
    }
}

world agentic-typesafe {
    import golem:agent/guest;
    export golem:agent/guest;
    export simulated-agent;
}


```