### PR TITLE
Extend type mapping tests

### DIFF
--- a/golem-ts-sdk/src/mapping/type-mapping.ts
+++ b/golem-ts-sdk/src/mapping/type-mapping.ts
@@ -259,7 +259,11 @@ export function constructAnalysedTypeFromTsType(type: TsType): AnalysedType {
 
         case TypeKind.Object:
             const object = type as ObjectType;
-            const objectFields = object.getProperties().map(prop => {
+            const props = object.getProperties();
+            if (props.length === 0) {
+               throw new Error(`Unsupported type for type ${type}`);
+            }
+            const objectFields = props.map(prop => {
                 return analysedType.field(prop.name.toString(), constructAnalysedTypeFromTsType(prop.type));
             });
             return analysedType.record(objectFields);

--- a/golem-ts-sdk/src/mapping/type-mapping.ts
+++ b/golem-ts-sdk/src/mapping/type-mapping.ts
@@ -154,6 +154,7 @@ export function constructAnalysedTypeFromTsType(type: TsType): AnalysedType {
             return analysedType.list(analysedType.tuple([weakKey, weakValue]));
 
         case TypeKind.SetDefinition:
+            throw new Error("set types are not supported in Golem");
         case TypeKind.WeakSetDefinition:
             const setType = type.getTypeArguments?.()[0];
             if (!setType) {
@@ -212,13 +213,19 @@ export function constructAnalysedTypeFromTsType(type: TsType): AnalysedType {
             return analysedType.list(constructAnalysedTypeFromTsType(asyncIterableIteratorType));
 
         case TypeKind.Type:
-            const arg = type.getTypeArguments?.()[0];
-            if (!arg) {
-                throw new Error("Type must have a type argument");
+            const typeArg = type.getTypeArguments?.()[0];
+            if (!typeArg) {
+                throw new Error("Array must have a type argument");
             }
 
-            return constructAnalysedTypeFromTsType(arg);
-
+            if (type.isArray()) {
+                return analysedType.list(constructAnalysedTypeFromTsType(typeArg));
+            }  else if (type.isTuple()) {
+                const tupleTypes = type.getTypeArguments?.().map(constructAnalysedTypeFromTsType) || [];
+                return analysedType.tuple(tupleTypes);
+            } else {
+                return constructAnalysedTypeFromTsType(typeArg);
+            }
 
         // To be handled
         case TypeKind.Module:
@@ -444,6 +451,8 @@ export function constructAnalysedTypeFromTsType(type: TsType): AnalysedType {
             return analysedType.tuple(tupleTypes);
 
         case TypeKind.ArrayDefinition:
+            throw new Error("type is not supported in Golem");
+
         case TypeKind.ReadonlyArrayDefinition:
             const elementType = type.getTypeArguments?.()[0];
             if (!elementType) {

--- a/golem-ts-sdk/tests/mapping.test.ts
+++ b/golem-ts-sdk/tests/mapping.test.ts
@@ -11,7 +11,6 @@ describe('TypeScript Interface to AnalysedType', () => {
     const analysed = constructAnalysedTypeFromTsType(interfaceType);
     const recordFields = getRecordFieldsFromAnalysedType(analysed)!;
 
-
     it('Interface should be AnalysedType.Record', () => {
         expect(analysed).toBeDefined();
         expect(analysed.kind).toBe('record');
@@ -57,6 +56,7 @@ describe('TypeScript Interface to AnalysedType', () => {
     it('Map type within an interface', () => {
         checkMapFields(recordFields);
     })
+
 });
 
 describe('TypeScript Object to AnalysedType', () => {

--- a/golem-ts-sdk/tests/mapping.test.ts
+++ b/golem-ts-sdk/tests/mapping.test.ts
@@ -5,9 +5,42 @@ import {
 } from "./utils";
 import {NameTypePair} from "../src/mapping/analysed-type";
 
-describe('TypeScript Interface to AnalysedType/WitType mapping', () => {
-    it('correctly analyses fields of the test interface', () => {
-        const interfaceType = getTestInterfaceType();
+describe('TypeScript Interface to AnalysedType', () => {
+    const interfaceType = getTestInterfaceType();
+    const analysed = constructAnalysedTypeFromTsType(interfaceType);
+    const recordFields = getRecordFieldsFromAnalysedType(analysed)!;
+
+
+    it('Interface should be AnalysedType.Record', () => {
+        expect(analysed).toBeDefined();
+        expect(analysed.kind).toBe('record');
+    })
+
+    it('Primitive types within an interface', () => {
+        checkPrimitiveFields(recordFields);
+    });
+
+    it('Undefined types within an interface', () => {
+        checkUndefinedFields(recordFields);
+    })
+
+    it('Optional fields within an interface', () => {
+        checkOptionalFields(recordFields);
+        checkOptionalUndefinedFields(recordFields);
+    })
+
+    it('Union types (aliased) within an interface', () => {
+        checkUnionFields(recordFields);
+    })
+
+    it('Object types within an interface', () => {
+        checkObjectFields(recordFields);
+    })
+});
+
+describe('TypeScript Object to AnalysedType', () => {
+    it('transforms object with different properties successfully to analysed type', () => {
+        const interfaceType = getTestObjectType();
         const analysed = constructAnalysedTypeFromTsType(interfaceType);
 
         expect(analysed).toBeDefined();
@@ -15,12 +48,22 @@ describe('TypeScript Interface to AnalysedType/WitType mapping', () => {
 
         const recordFields = getRecordFieldsFromAnalysedType(analysed)!;
 
-        checkPrimitiveFields(recordFields);
-        checkUndefinedFields(recordFields);
-        checkOptionalFields(recordFields);
-        checkOptionalUndefinedFields(recordFields);
-        checkUnionFields(recordFields);
-        checkObjectFields(recordFields);
+        const expected: NameTypePair[] = [
+            {
+                name: "a",
+                typ: { kind: 'string' }
+            },
+            {
+                name: "b",
+                typ: { kind: 's32' }
+            },
+            {
+                name: "c",
+                typ: { kind: 'bool'}
+            }
+        ]
+
+        expect(recordFields).toEqual(expected);
     });
 });
 

--- a/golem-ts-sdk/tests/mapping.test.ts
+++ b/golem-ts-sdk/tests/mapping.test.ts
@@ -53,6 +53,10 @@ describe('TypeScript Interface to AnalysedType', () => {
     it ('Tuple with object type within an interface', () => {
         checkTupleWithObjectFields(recordFields);
     })
+
+    it('Map type within an interface', () => {
+        checkMapFields(recordFields);
+    })
 });
 
 describe('TypeScript Object to AnalysedType', () => {
@@ -84,7 +88,7 @@ describe('TypeScript Object to AnalysedType', () => {
     });
 });
 
-// To be confirmed. 
+// To be confirmed.
 describe('TypeScript Union to AnalysedType.Variant', () => {
     it('Union is converted to Variant with the name of the type as case name', () => {
         const enumType = getUnionType();
@@ -236,6 +240,23 @@ function checkTupleWithObjectFields(fields: any[]) {
                 ], name: undefined } }
             ];
             expect(field.typ.value.items).toEqual(expected);
+        }
+    });
+}
+
+function checkMapFields(fields: any[]) {
+    const mapFields = fields.filter(f => f.name.startsWith('mapProp'));
+    expect(mapFields.length).toBeGreaterThan(0);
+
+    // list of tuples, where each tuple is a key-value pair
+    mapFields.forEach(field => {
+        expect(field.typ.kind).toBe('list');
+        if (field.typ.kind == 'list') {
+            expect(field.typ.value.inner.kind).toBe('tuple');
+            const inner = field.typ.value.inner;
+            expect(inner.value.items.length).toBe(2);
+            expect(inner.value.items[0].kind).toBe('string');
+            expect(inner.value.items[1].kind).toBe('s32');
         }
     });
 }

--- a/golem-ts-sdk/tests/mapping.test.ts
+++ b/golem-ts-sdk/tests/mapping.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {constructAnalysedTypeFromTsType} from "../src/mapping/type-mapping";
 import {
-    expectTupleTypeWithNoItems, getTestInterfaceType, getRecordFieldsFromAnalysedType,
+    expectTupleTypeWithNoItems, getTestInterfaceType, getRecordFieldsFromAnalysedType, getTestObjectType,
 } from "./utils";
 import {NameTypePair} from "../src/mapping/analysed-type";
 
-describe('TypeScript interface to AnalysedType/WitType mapping', () => {
+describe('TypeScript Interface to AnalysedType/WitType mapping', () => {
     it('correctly analyses fields of the test interface', () => {
         const interfaceType = getTestInterfaceType();
         const analysed = constructAnalysedTypeFromTsType(interfaceType);
@@ -21,6 +21,35 @@ describe('TypeScript interface to AnalysedType/WitType mapping', () => {
         checkOptionalUndefinedFields(recordFields);
         checkUnionFields(recordFields);
         checkObjectFields(recordFields);
+    });
+});
+
+describe('TypeScript Object to AnalysedType/WitType mapping', () => {
+    it('correctly analyses fields of the test interface', () => {
+        const interfaceType = getTestObjectType();
+        const analysed = constructAnalysedTypeFromTsType(interfaceType);
+
+        expect(analysed).toBeDefined();
+        expect(analysed.kind).toBe('record');
+
+        const recordFields = getRecordFieldsFromAnalysedType(analysed)!;
+
+        const expected: NameTypePair[] = [
+            {
+                name: "a",
+                typ: { kind: 'string' }
+            },
+            {
+                name: "b",
+                typ: { kind: 's32' }
+            },
+            {
+                name: "c",
+                typ: { kind: 'bool'}
+            }
+        ]
+
+        expect(recordFields).toEqual(expected);
     });
 });
 

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -27,6 +27,10 @@ type ListType = Array<string>;
 
 type ListObjectType = Array<ObjectType>;
 
+type TupleType = [string, number, boolean];
+
+type TupleWithObjectType = [string, number, ObjectType];
+
 // enum EnumType {
 //     First = 'First',
 //     Second = 1,
@@ -53,6 +57,8 @@ export interface TestInterfaceType {
     objectProp: ObjectType,
     listProp: ListType,
     listObjectProp: ListObjectType,
+    tupleProp: TupleType,
+    tupleObjectProp: TupleWithObjectType,
     // enumType: EnumTypeAlias; // FIXME, RTTIST bug
     //enumTypeInlined: EnumType, // FIXME, RTTIST bug
     // objectPropInlined: { // FIXME, RTTIST bug

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -33,13 +33,6 @@ type TupleWithObjectType = [string, number, ObjectType];
 
 type MapType = Map<string, number>;
 
-// enum EnumType {
-//     First = 'First',
-//     Second = 1,
-// }
-//
-// type EnumTypeAlias = EnumType;
-
 export interface TestInterfaceType {
     numberProp: number;
     stringProp: string;
@@ -55,20 +48,34 @@ export interface TestInterfaceType {
     optionalUndefinedProp?: undefined,
     nestedProp: SimpleInterfaceType;
     unionProp: UnionType,
-    //unionPropInlined: string | number; //FIXME, RTTIST bug
     objectProp: ObjectType,
     listProp: ListType,
     listObjectProp: ListObjectType,
     tupleProp: TupleType,
     tupleObjectProp: TupleWithObjectType,
     mapProp: MapType,
-    // enumType: EnumTypeAlias; // FIXME, RTTIST bug
-    //enumTypeInlined: EnumType, // FIXME, RTTIST bug
-    // objectPropInlined: { // FIXME, RTTIST bug
+    //FIXME, RTTIST bug or not supported yet
+    // mapAlternativeProp: MapTypeAlternative,
+    //unionPropInlined: string | number;
+    // recordProp: RecordType;
+    // enumType: EnumTypeAlias;
+    //enumTypeInlined: EnumType,
+    // objectPropInlined: {
     //     a: string,
     //     b: number,
     //     c: boolean
     // }
     //enumProp: EnumTypeAlias,
-    // enumPropInlined: EnumTypeAlias, // FIXME, RTTIST bug
+    // enumPropInlined: EnumTypeAlias,
 }
+
+// FIXME: RTTIST don't support these yet
+// type MapTypeAlternative = { [key: string]: number };
+// type RecordType = Record<number, string>;
+
+// enum EnumType {
+//     First = 'First',
+//     Second = 1,
+// }
+//
+// type EnumTypeAlias = EnumType;

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -23,6 +23,10 @@ type UnionType = number | string | boolean;
 
 type ObjectType = {a: string, b: number, c: boolean}
 
+type ListType = Array<string>;
+
+type ListObjectType = Array<ObjectType>;
+
 // enum EnumType {
 //     First = 'First',
 //     Second = 1,
@@ -47,6 +51,8 @@ export interface TestInterfaceType {
     unionProp: UnionType,
     //unionPropInlined: string | number; //FIXME, RTTIST bug
     objectProp: ObjectType,
+    listProp: ListType,
+    listObjectProp: ListObjectType,
     // enumType: EnumTypeAlias; // FIXME, RTTIST bug
     //enumTypeInlined: EnumType, // FIXME, RTTIST bug
     // objectPropInlined: { // FIXME, RTTIST bug

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -30,7 +30,7 @@ type ObjectType = {a: string, b: number, c: boolean}
 //
 // type EnumTypeAlias = EnumType;
 
-interface TestInterfaceType {
+export interface TestInterfaceType {
     numberProp: number;
     stringProp: string;
     booleanProp: boolean;

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -31,6 +31,8 @@ type TupleType = [string, number, boolean];
 
 type TupleWithObjectType = [string, number, ObjectType];
 
+type MapType = Map<string, number>;
+
 // enum EnumType {
 //     First = 'First',
 //     Second = 1,
@@ -59,6 +61,7 @@ export interface TestInterfaceType {
     listObjectProp: ListObjectType,
     tupleProp: TupleType,
     tupleObjectProp: TupleWithObjectType,
+    mapProp: MapType,
     // enumType: EnumTypeAlias; // FIXME, RTTIST bug
     //enumTypeInlined: EnumType, // FIXME, RTTIST bug
     // objectPropInlined: { // FIXME, RTTIST bug

--- a/golem-ts-sdk/tests/utils.ts
+++ b/golem-ts-sdk/tests/utils.ts
@@ -13,6 +13,10 @@ export function getTestInterfaceType(): Type {
     return getAll().filter((type) => type.name == 'TestInterfaceType')[0];
 }
 
+export function getTestObjectType(): Type {
+    return getAll().filter((type) => type.name == 'ObjectType')[0];
+}
+
 export function expectTupleTypeWithNoItems(typ: AnalysedType) {
     expect(typ.kind).toBe('tuple');
     const itemsLength = typ?.kind === 'tuple' ? typ.value.items.length : -1;

--- a/golem-ts-sdk/tests/utils.ts
+++ b/golem-ts-sdk/tests/utils.ts
@@ -17,6 +17,10 @@ export function getTestObjectType(): Type {
     return getAll().filter((type) => type.name == 'ObjectType')[0];
 }
 
+export function getUnionType(): Type {
+    return getAll().filter((type) => type.name == 'UnionType')[0];
+}
+
 export function expectTupleTypeWithNoItems(typ: AnalysedType) {
     expect(typ.kind).toBe('tuple');
     const itemsLength = typ?.kind === 'tuple' ? typ.value.items.length : -1;


### PR DESCRIPTION
- tuple (nested etc)
- array (nested etc)
- object (nested etc)
- map (key-value pair)
- interface
- union types (variants , hmmm)
- primitives and others:
   *  void, undefined, unknown
   * string, boolean, number, bigint


### Unsupported types tracked

* inlined object (to be fixed in RTTIST). Works with only type-alias
   ```
     function ask(input: {a: string}) // Won't work
     type Input = {a: string}
     function ask(input: input) // Works
   ```
* enum (to be fixed in RTTIST)
* Record<type1, type2>
* {[key: string], number} (Map is supported though)



### Documentation requirement

* List of types that are supported
* And make sure to recommend users to not inline object types


### Immediate Fix required in RTTIST
* Enum type


As code, you can see the above observations here: https://github.com/golemcloud/golem-agentic/blob/value_mapping_tests/golem-ts-sdk/tests/test-data.ts#L57

