### PR TITLE
Extend property based tests for specific simple types

### DIFF
--- a/golem-ts-sdk/tests/arbitraries.ts
+++ b/golem-ts-sdk/tests/arbitraries.ts
@@ -5,21 +5,24 @@ import {
   MapType,
   ObjectType,
   TestInterfaceType,
+  TupleComplexType,
+  TupleType,
+  UnionType,
 } from './test-data';
 
-export const testMapArb: fc.Arbitrary<MapType> = fc
+export const mapArb: fc.Arbitrary<MapType> = fc
   .dictionary(fc.string(), fc.integer())
   .map((obj) => new Map(Object.entries(obj)));
 
-export const testObjectArb: fc.Arbitrary<ObjectType> = fc.record({
+export const objectArb: fc.Arbitrary<ObjectType> = fc.record({
   a: fc.string(),
   b: fc.integer(),
   c: fc.boolean(),
 });
 
-export const testListArb: fc.Arbitrary<ListType> = fc.array(fc.string());
+export const listArb: fc.Arbitrary<ListType> = fc.array(fc.string());
 
-export const testOfListObjectArb: fc.Arbitrary<ListObjectType> = fc.array(
+export const listOfObjArb: fc.Arbitrary<ListObjectType> = fc.array(
   fc.record({
     a: fc.string(),
     b: fc.integer(),
@@ -27,50 +30,48 @@ export const testOfListObjectArb: fc.Arbitrary<ListObjectType> = fc.array(
   }),
 );
 
-export const testInterfaceTypeArb: fc.Arbitrary<TestInterfaceType> = fc.record({
-  bigintProp: fc.bigInt(),
-  booleanProp: fc.boolean(),
-  falseProp: fc.constant(false),
-  listObjectProp: fc.array(
-    fc.record({
-      a: fc.string(),
-      b: fc.integer(),
-      c: fc.boolean(),
-    }),
-  ),
-  listProp: fc.array(fc.string()),
-  mapProp: fc
-    .dictionary(fc.string(), fc.integer())
-    .map((obj) => new Map(Object.entries(obj))),
-  nestedProp: fc.record({ n: fc.integer() }),
-  nullProp: fc.constant(null),
-  numberProp: fc.integer(),
-  objectProp: fc.record({
+export const unionArb: fc.Arbitrary<UnionType> = fc.oneof(
+  fc.integer(),
+  fc.string(),
+  fc.boolean(),
+  fc.record({
     a: fc.string(),
     b: fc.integer(),
     c: fc.boolean(),
   }),
+);
+
+export const tupleArb: fc.Arbitrary<TupleType> = fc.tuple(
+  fc.string(),
+  fc.integer(),
+  fc.boolean(),
+);
+
+export const tupleComplexArb: fc.Arbitrary<TupleComplexType> = fc.tuple(
+  fc.string(),
+  fc.integer(),
+  fc.record({
+    a: fc.string(),
+    b: fc.integer(),
+    c: fc.boolean(),
+  }),
+);
+
+export const interfaceArb: fc.Arbitrary<TestInterfaceType> = fc.record({
+  bigintProp: fc.bigInt(),
+  booleanProp: fc.boolean(),
+  falseProp: fc.constant(false),
+  listObjectProp: listOfObjArb,
+  listProp: listArb,
+  mapProp: mapArb,
+  nestedProp: fc.record({ n: fc.integer() }),
+  nullProp: fc.constant(null),
+  numberProp: fc.integer(),
+  objectProp: objectArb,
   stringProp: fc.string(),
   trueProp: fc.constant(true),
-  tupleObjectProp: fc.tuple(
-    fc.string(),
-    fc.integer(),
-    fc.record({
-      a: fc.string(),
-      b: fc.integer(),
-      c: fc.boolean(),
-    }),
-  ),
-  tupleProp: fc.tuple(fc.string(), fc.integer(), fc.boolean()),
-  unionProp: fc.oneof(
-    fc.integer(),
-    fc.string(),
-    fc.boolean(),
-    fc.record({
-      a: fc.string(),
-      b: fc.integer(),
-      c: fc.boolean(),
-    }),
-  ),
+  tupleObjectProp: tupleComplexArb,
+  tupleProp: tupleArb,
+  unionProp: unionArb,
   optionalProp: fc.option(fc.integer(), { nil: undefined }),
 });

--- a/golem-ts-sdk/tests/arbitraries.ts
+++ b/golem-ts-sdk/tests/arbitraries.ts
@@ -1,5 +1,31 @@
 import * as fc from 'fast-check';
-import { TestInterfaceType } from './test-data';
+import {
+  ListObjectType,
+  ListType,
+  MapType,
+  ObjectType,
+  TestInterfaceType,
+} from './test-data';
+
+export const testMapArb: fc.Arbitrary<MapType> = fc
+  .dictionary(fc.string(), fc.integer())
+  .map((obj) => new Map(Object.entries(obj)));
+
+export const testObjectArb: fc.Arbitrary<ObjectType> = fc.record({
+  a: fc.string(),
+  b: fc.integer(),
+  c: fc.boolean(),
+});
+
+export const testListArb: fc.Arbitrary<ListType> = fc.array(fc.string());
+
+export const testOfListObjectArb: fc.Arbitrary<ListObjectType> = fc.array(
+  fc.record({
+    a: fc.string(),
+    b: fc.integer(),
+    c: fc.boolean(),
+  }),
+);
 
 export const testInterfaceTypeArb: fc.Arbitrary<TestInterfaceType> = fc.record({
   bigintProp: fc.bigInt(),

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -21,17 +21,17 @@ interface SimpleInterfaceType {
 // This needs to be verified with @vigoo
 type UnionType = number | string | boolean | ObjectType;
 
-type ObjectType = { a: string; b: number; c: boolean };
+export type ObjectType = { a: string; b: number; c: boolean };
 
-type ListType = Array<string>;
+export type ListType = Array<string>;
 
-type ListObjectType = Array<ObjectType>;
+export type ListObjectType = Array<ObjectType>;
 
 type TupleType = [string, number, boolean];
 
 type TupleWithObjectType = [string, number, ObjectType];
 
-type MapType = Map<string, number>;
+export type MapType = Map<string, number>;
 
 export interface TestInterfaceType {
   numberProp: number;

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -19,7 +19,7 @@ interface SimpleInterfaceType {
 // A union type will become a variant in WIT, and the names will be available in the case.name
 // Example: [{name: 'string', typ: { kind: 'string' }}, {name: 'number', typ: { kind: 's32' }}]
 // This needs to be verified with @vigoo
-type UnionType = number | string | boolean | ObjectType;
+export type UnionType = number | string | boolean | ObjectType;
 
 export type ObjectType = { a: string; b: number; c: boolean };
 
@@ -27,9 +27,9 @@ export type ListType = Array<string>;
 
 export type ListObjectType = Array<ObjectType>;
 
-type TupleType = [string, number, boolean];
+export type TupleType = [string, number, boolean];
 
-type TupleWithObjectType = [string, number, ObjectType];
+export type TupleComplexType = [string, number, ObjectType];
 
 export type MapType = Map<string, number>;
 
@@ -48,7 +48,7 @@ export interface TestInterfaceType {
   listProp: ListType;
   listObjectProp: ListObjectType;
   tupleProp: TupleType;
-  tupleObjectProp: TupleWithObjectType;
+  tupleObjectProp: TupleComplexType;
   mapProp: MapType;
   //FIXME, RTTIST bug or not supported yet
   // mapAlternativeProp: MapTypeAlternative,

--- a/golem-ts-sdk/tests/utils.ts
+++ b/golem-ts-sdk/tests/utils.ts
@@ -36,6 +36,14 @@ export function getUnionType(): Type {
   return fetchType('UnionType');
 }
 
+export function getTupleType(): Type {
+  return fetchType('TupleType');
+}
+
+export function getTupleComplexType(): Type {
+  return fetchType('TupleComplexType');
+}
+
 export function expectTupleTypeWithNoItems(typ: AnalysedType) {
   expect(typ.kind).toBe('tuple');
   const itemsLength = typ?.kind === 'tuple' ? typ.value.items.length : -1;

--- a/golem-ts-sdk/tests/utils.ts
+++ b/golem-ts-sdk/tests/utils.ts
@@ -4,6 +4,7 @@ import { Type } from 'rttist';
 import './setup';
 import { AnalysedType, NameTypePair } from '../src/mapping/types/analysed-type';
 import { expect } from 'vitest';
+import { ListObjectType } from './test-data';
 
 export function getAll() {
   return Metadata.getTypes().filter(
@@ -12,15 +13,27 @@ export function getAll() {
 }
 
 export function getTestInterfaceType(): Type {
-  return getAll().filter((type) => type.name == 'TestInterfaceType')[0];
+  return fetchType('TestInterfaceType');
+}
+
+export function getTestMapType(): Type {
+  return fetchType('MapType');
 }
 
 export function getTestObjectType(): Type {
-  return getAll().filter((type) => type.name == 'ObjectType')[0];
+  return fetchType('ObjectType');
+}
+
+export function getTestListType(): Type {
+  return fetchType('ListType');
+}
+
+export function getTestListOfObjectType(): Type {
+  return fetchType('ListObjectType');
 }
 
 export function getUnionType(): Type {
-  return getAll().filter((type) => type.name == 'UnionType')[0];
+  return fetchType('UnionType');
 }
 
 export function expectTupleTypeWithNoItems(typ: AnalysedType) {
@@ -33,4 +46,13 @@ export function getRecordFieldsFromAnalysedType(
   analysedType: AnalysedType,
 ): NameTypePair[] | undefined {
   return analysedType.kind === 'record' ? analysedType.value.fields : undefined;
+}
+
+function fetchType(typeNameInTestData: string): Type {
+  const types = getAll().filter((type) => type.name == typeNameInTestData);
+
+  if (types.length === 0) {
+    throw new Error(`Type ${typeNameInTestData} not found in test data`);
+  }
+  return types[0];
 }

--- a/golem-ts-sdk/tests/value.mapping.test.ts
+++ b/golem-ts-sdk/tests/value.mapping.test.ts
@@ -14,21 +14,7 @@ describe('typescript value to wit value round-trip conversions', () => {
   it('should correctly perform round-trip conversion for arbitrary values of interface type', () => {
     fc.assert(
       fc.property(testInterfaceTypeArb, (data) => {
-        const interfaceType = getTestInterfaceType();
-        const witValue = constructWitValueFromTsValue(data, interfaceType);
-
-        // Round trip wit-value -> value -> wit-value
-        const value = constructValueFromWitValue(witValue);
-        const witValueReturned = constructWitValueFromValue(value);
-        expect(witValueReturned).toEqual(witValue);
-
-        // Round trip ts-value -> wit-value -> ts-value
-        const tsValueReturned: TestInterfaceType = constructTsValueFromWitValue(
-          witValueReturned,
-          interfaceType,
-        );
-
-        expect(tsValueReturned).toEqual(data);
+        runRoundTripTest(data as TestInterfaceType);
       }),
     );
   });
@@ -52,21 +38,7 @@ describe('typescript value to wit value round-trip conversions', () => {
       unionProp: 1,
     };
 
-    const interfaceType = getTestInterfaceType();
-    const witValue = constructWitValueFromTsValue(defaultData, interfaceType);
-
-    // Round trip wit-value -> value -> wit-value
-    const value = constructValueFromWitValue(witValue);
-    const witValueReturned = constructWitValueFromValue(value);
-    expect(witValueReturned).toEqual(witValue);
-
-    // Round trip ts-value -> wit-value -> ts-value
-    const tsValueReturned: TestInterfaceType = constructTsValueFromWitValue(
-      witValueReturned,
-      interfaceType,
-    );
-
-    expect(tsValueReturned).toEqual(defaultData);
+    runRoundTripTest(defaultData);
   });
 
   it('should preserve values including optional properties', () => {
@@ -89,24 +61,7 @@ describe('typescript value to wit value round-trip conversions', () => {
       optionalProp: 2,
     };
 
-    const interfaceType = getTestInterfaceType();
-    const witValue = constructWitValueFromTsValue(
-      withOptionalValues,
-      interfaceType,
-    );
-
-    // Round trip wit-value -> value -> wit-value
-    const value = constructValueFromWitValue(witValue);
-    const witValueReturned = constructWitValueFromValue(value);
-    expect(witValueReturned).toEqual(witValue);
-
-    // Round trip ts-value -> wit-value -> ts-value
-    const tsValueReturned: TestInterfaceType = constructTsValueFromWitValue(
-      witValue,
-      interfaceType,
-    );
-
-    expect(tsValueReturned).toEqual(withOptionalValues);
+    runRoundTripTest(withOptionalValues);
   });
 
   it('should preserve union properties with complex object variants', () => {
@@ -129,23 +84,24 @@ describe('typescript value to wit value round-trip conversions', () => {
       optionalProp: 2,
     };
 
-    const interfaceType = getTestInterfaceType();
-    const witValue = constructWitValueFromTsValue(
-      withComplexUnionType,
-      interfaceType,
-    );
-
-    // Round trip wit-value -> value -> wit-value
-    const value = constructValueFromWitValue(witValue);
-    const witValueReturned = constructWitValueFromValue(value);
-    expect(witValueReturned).toEqual(witValue);
-
-    // Round trip ts-value -> wit-value -> ts-value
-    const tsValueReturned: TestInterfaceType = constructTsValueFromWitValue(
-      witValue,
-      interfaceType,
-    );
-
-    expect(tsValueReturned).toEqual(withComplexUnionType);
+    runRoundTripTest(withComplexUnionType);
   });
 });
+
+function runRoundTripTest(data: TestInterfaceType) {
+  const interfaceType = getTestInterfaceType();
+  const witValue = constructWitValueFromTsValue(data, interfaceType);
+
+  // Round trip wit-value -> value -> wit-value
+  const value = constructValueFromWitValue(witValue);
+  const witValueReturned = constructWitValueFromValue(value);
+  expect(witValueReturned).toEqual(witValue);
+
+  // Round trip ts-value -> wit-value -> ts-value
+  const tsValueReturned: TestInterfaceType = constructTsValueFromWitValue(
+      witValueReturned,
+      interfaceType,
+  );
+
+  expect(tsValueReturned).toEqual(data);
+}

--- a/golem-ts-sdk/tests/value.mapping.test.ts
+++ b/golem-ts-sdk/tests/value.mapping.test.ts
@@ -99,8 +99,8 @@ function runRoundTripTest(data: TestInterfaceType) {
 
   // Round trip ts-value -> wit-value -> ts-value
   const tsValueReturned: TestInterfaceType = constructTsValueFromWitValue(
-      witValueReturned,
-      interfaceType,
+    witValueReturned,
+    interfaceType,
   );
 
   expect(tsValueReturned).toEqual(data);

--- a/golem-ts-sdk/tests/value.mapping.test.ts
+++ b/golem-ts-sdk/tests/value.mapping.test.ts
@@ -5,6 +5,8 @@ import {
   getTestObjectType,
   getTestListType,
   getTestListOfObjectType,
+  getTupleComplexType,
+  getTupleType,
 } from './utils';
 import { TestInterfaceType } from './test-data';
 import {
@@ -14,11 +16,13 @@ import {
 import { constructWitValueFromTsValue } from '../src/mapping/values/ts-to-wit';
 import { constructTsValueFromWitValue } from '../src/mapping/values/wit-to-ts';
 import {
-  testInterfaceTypeArb,
-  testListArb,
-  testMapArb,
-  testObjectArb,
-  testOfListObjectArb,
+  interfaceArb,
+  listArb,
+  mapArb,
+  objectArb,
+  listOfObjArb,
+  tupleComplexArb,
+  tupleArb,
 } from './arbitraries';
 import * as fc from 'fast-check';
 import { Type } from 'rttist';
@@ -26,7 +30,7 @@ import { Type } from 'rttist';
 describe('typescript value to wit value round-trip conversions', () => {
   it('should correctly perform round-trip conversion for arbitrary values of interface type', () => {
     fc.assert(
-      fc.property(testInterfaceTypeArb, (arbData) => {
+      fc.property(interfaceArb, (arbData) => {
         const type = getTestInterfaceType();
         runRoundTripTest(arbData, type);
       }),
@@ -35,7 +39,7 @@ describe('typescript value to wit value round-trip conversions', () => {
 
   it('should correctly perform round-trip conversion for arbitrary values of object type', () => {
     fc.assert(
-      fc.property(testObjectArb, (arbData) => {
+      fc.property(objectArb, (arbData) => {
         const type = getTestObjectType();
         runRoundTripTest(arbData, type);
       }),
@@ -44,7 +48,7 @@ describe('typescript value to wit value round-trip conversions', () => {
 
   it('should correctly perform round-trip conversion for arbitrary values of map type', () => {
     fc.assert(
-      fc.property(testMapArb, (arbData) => {
+      fc.property(mapArb, (arbData) => {
         const type = getTestMapType();
         runRoundTripTest(arbData, type);
       }),
@@ -53,7 +57,7 @@ describe('typescript value to wit value round-trip conversions', () => {
 
   it('should correctly perform round-trip conversion for arbitrary values of list type', () => {
     fc.assert(
-      fc.property(testListArb, (arbData) => {
+      fc.property(listArb, (arbData) => {
         const type = getTestListType();
         runRoundTripTest(arbData, type);
       }),
@@ -62,9 +66,21 @@ describe('typescript value to wit value round-trip conversions', () => {
 
   it('should correctly perform round-trip conversion for arbitrary values of list of object type', () => {
     fc.assert(
-      fc.property(testOfListObjectArb, (arbData) => {
+      fc.property(listOfObjArb, (arbData) => {
         const type = getTestListOfObjectType();
         runRoundTripTest(arbData, type);
+      }),
+    );
+  });
+
+  it('should correctly perform round-trip conversion for arbitrary values of complex tuple', () => {
+    fc.assert(
+      fc.property(tupleArb, tupleComplexArb, (tupleData, tupleComplexData) => {
+        const simpleType = getTupleType();
+        runRoundTripTest(tupleData, simpleType);
+
+        const type = getTupleComplexType();
+        runRoundTripTest(tupleComplexData, type);
       }),
     );
   });


### PR DESCRIPTION
the setup of property based test, with complex interface type was already merged.
This PR is already extending with types independently.