### PR TITLE
Extend property test with complex objects and union

### DIFF
--- a/golem-ts-sdk/src/mapping/types/ts-to-wit.ts
+++ b/golem-ts-sdk/src/mapping/types/ts-to-wit.ts
@@ -3,128 +3,17 @@ import {
     NameOptionTypePair,
     NameTypePair,
 } from './analysed-type';
-import {NamedWitTypeNode, NodeIndex, ResourceMode, WitTypeNode} from "golem:rpc/types@0.2.2";
 import {WitType} from "golem:agent/common";
 import {EnumType, GenericType, Type, TypeAliasType, UnionType} from "rttist";
 import {InterfaceType, ObjectType, Type as TsType, TypeKind} from "rttist";
 import {analysedType} from "./analysed-type";
+import {WitTypeBuilder} from "./wit-type-builder";
 
 export function constructWitTypeFromTsType(type: Type) : WitType {
     const analysedType = constructAnalysedTypeFromTsType(type)
-
     const builder = new WitTypeBuilder();
     builder.add(analysedType);
     return builder.build();
-}
-
-// Copied from wasm-rpc rust implementation
-class WitTypeBuilder {
-    private nodes: NamedWitTypeNode[] = [];
-    private mapping = new Map<string, number>();
-
-    add(typ: AnalysedType): NodeIndex {
-        const hash = JSON.stringify(typ);
-        if (this.mapping.has(hash)) {
-            return this.mapping.get(hash)!;
-        }
-
-        const idx = this.nodes.length;
-        const boolType: WitTypeNode = { tag: 'prim-bool-type' };
-        this.nodes.push({  name: undefined,  type: boolType });
-
-        const node: WitTypeNode = this.convert(typ);
-        const name = getNameFromAnalysedType(typ);
-        this.nodes[idx] = { name, type: node };
-        this.mapping.set(hash, idx);
-        return idx;
-    }
-
-    build(): WitType {
-        return { nodes: this.nodes };
-    }
-
-    private convert(typ: AnalysedType): WitTypeNode {
-        switch (typ.kind) {
-            case 'variant': {
-                const cases: [string, NodeIndex | undefined][] = typ.value.cases.map(
-                    (c: NameOptionTypePair) => [c.name, c.typ ? this.add(c.typ) : undefined],
-                );
-                return { tag: 'variant-type', val: cases };
-            }
-
-            case 'result': {
-                const ok = typ.value.ok ? this.add(typ.value.ok) : undefined;
-                const err = typ.value.err ? this.add(typ.value.err) : undefined;
-                return { tag: 'result-type', val: [ok, err] };
-            }
-
-            case 'option': {
-                const inner = this.add(typ.value.inner);
-                return { tag: 'option-type', val: inner };
-            }
-
-            case 'enum':
-                return { tag: 'enum-type', val: typ.value.cases };
-
-            case 'flags':
-                return { tag: 'flags-type', val: typ.value.names };
-
-            case 'record': {
-                const fields: [string, NodeIndex][] = typ.value.fields.map(
-                    (f: NameTypePair) => [f.name, this.add(f.typ)],
-                );
-                return { tag: 'record-type', val: fields };
-            }
-
-            case 'tuple': {
-                const elements = typ.value.items.map((item) => this.add(item));
-                return { tag: 'tuple-type', val: elements };
-            }
-
-            case 'list': {
-                const inner = this.add(typ.value.inner);
-                return { tag: 'list-type', val: inner };
-            }
-
-            case 'string':
-                return { tag: 'prim-string-type' };
-            case 'chr':
-                return { tag: 'prim-char-type' };
-            case 'f64':
-                return { tag: 'prim-f64-type' };
-            case 'f32':
-                return { tag: 'prim-f32-type' };
-            case 'u64':
-                return { tag: 'prim-u64-type' };
-            case 's64':
-                return { tag: 'prim-s64-type' };
-            case 'u32':
-                return { tag: 'prim-u32-type' };
-            case 's32':
-                return { tag: 'prim-s32-type' };
-            case 'u16':
-                return { tag: 'prim-u16-type' };
-            case 's16':
-                return { tag: 'prim-s16-type' };
-            case 'u8':
-                return { tag: 'prim-u8-type' };
-            case 's8':
-                return { tag: 'prim-s8-type' };
-            case 'bool':
-                return { tag: 'prim-bool-type' };
-
-            // FIXME: Why? typ.value.resourceId is a number and the handle-type takes a bigint
-            case 'handle': {
-                const resId: number = typ.value.resourceId;
-                const mode: ResourceMode =
-                    typ.value.mode === 'owned' ? 'owned' : 'borrowed';
-                return { tag: 'handle-type', val: [BigInt(resId), mode] };
-            }
-
-            default:
-                throw new Error(`Unhandled AnalysedType kind: ${(typ as any).kind}`);
-        }
-    }
 }
 
 export function constructAnalysedTypeFromTsType(type: TsType): AnalysedType {

--- a/golem-ts-sdk/src/mapping/types/wit-type-builder.ts
+++ b/golem-ts-sdk/src/mapping/types/wit-type-builder.ts
@@ -1,0 +1,113 @@
+// Copied from wasm-rpc rust implementation
+import {NamedWitTypeNode, NodeIndex, ResourceMode, WitTypeNode} from "golem:rpc/types@0.2.2";
+import {AnalysedType, getNameFromAnalysedType, NameOptionTypePair, NameTypePair} from "./analysed-type";
+import {WitType} from "golem:agent/common";
+
+export class WitTypeBuilder {
+    private nodes: NamedWitTypeNode[] = [];
+    private mapping = new Map<string, number>();
+
+    add(typ: AnalysedType): NodeIndex {
+        const hash = JSON.stringify(typ);
+        if (this.mapping.has(hash)) {
+            return this.mapping.get(hash)!;
+        }
+
+        const idx = this.nodes.length;
+        const boolType: WitTypeNode = { tag: 'prim-bool-type' };
+        this.nodes.push({  name: undefined,  type: boolType });
+
+        const node: WitTypeNode = this.convert(typ);
+        const name = getNameFromAnalysedType(typ);
+        this.nodes[idx] = { name, type: node };
+        this.mapping.set(hash, idx);
+        return idx;
+    }
+
+    build(): WitType {
+        return { nodes: this.nodes };
+    }
+
+    private convert(typ: AnalysedType): WitTypeNode {
+        switch (typ.kind) {
+            case 'variant': {
+                const cases: [string, NodeIndex | undefined][] = typ.value.cases.map(
+                    (c: NameOptionTypePair) => [c.name, c.typ ? this.add(c.typ) : undefined],
+                );
+                return { tag: 'variant-type', val: cases };
+            }
+
+            case 'result': {
+                const ok = typ.value.ok ? this.add(typ.value.ok) : undefined;
+                const err = typ.value.err ? this.add(typ.value.err) : undefined;
+                return { tag: 'result-type', val: [ok, err] };
+            }
+
+            case 'option': {
+                const inner = this.add(typ.value.inner);
+                return { tag: 'option-type', val: inner };
+            }
+
+            case 'enum':
+                return { tag: 'enum-type', val: typ.value.cases };
+
+            case 'flags':
+                return { tag: 'flags-type', val: typ.value.names };
+
+            case 'record': {
+                const fields: [string, NodeIndex][] = typ.value.fields.map(
+                    (f: NameTypePair) => [f.name, this.add(f.typ)],
+                );
+                return { tag: 'record-type', val: fields };
+            }
+
+            case 'tuple': {
+                const elements = typ.value.items.map((item) => this.add(item));
+                return { tag: 'tuple-type', val: elements };
+            }
+
+            case 'list': {
+                const inner = this.add(typ.value.inner);
+                return { tag: 'list-type', val: inner };
+            }
+
+            case 'string':
+                return { tag: 'prim-string-type' };
+            case 'chr':
+                return { tag: 'prim-char-type' };
+            case 'f64':
+                return { tag: 'prim-f64-type' };
+            case 'f32':
+                return { tag: 'prim-f32-type' };
+            case 'u64':
+                return { tag: 'prim-u64-type' };
+            case 's64':
+                return { tag: 'prim-s64-type' };
+            case 'u32':
+                return { tag: 'prim-u32-type' };
+            case 's32':
+                return { tag: 'prim-s32-type' };
+            case 'u16':
+                return { tag: 'prim-u16-type' };
+            case 's16':
+                return { tag: 'prim-s16-type' };
+            case 'u8':
+                return { tag: 'prim-u8-type' };
+            case 's8':
+                return { tag: 'prim-s8-type' };
+            case 'bool':
+                return { tag: 'prim-bool-type' };
+
+            // FIXME: Why? typ.value.resourceId is a number and the handle-type takes a bigint
+            case 'handle': {
+                const resId: number = typ.value.resourceId;
+                const mode: ResourceMode =
+                    typ.value.mode === 'owned' ? 'owned' : 'borrowed';
+                return { tag: 'handle-type', val: [BigInt(resId), mode] };
+            }
+
+            default:
+                throw new Error(`Unhandled AnalysedType kind: ${(typ as any).kind}`);
+        }
+    }
+}

--- a/golem-ts-sdk/src/mapping/values/ts-to-wit.ts
+++ b/golem-ts-sdk/src/mapping/values/ts-to-wit.ts
@@ -227,7 +227,9 @@ function handleUnion(tsValue: any, type: Type): Value {
   const typeWithIndex = findTypeOfAny(tsValue, possibleTypes);
 
   if (!typeWithIndex) {
-    throw new Error(`No matching type found for the value '${tsValue}' in union type. Type structure: ${unionType.displayName}`);
+    throw new Error(
+      `No matching type found for the value '${tsValue}' in union type. Type structure: ${unionType.displayName}`,
+    );
   } else {
     const innerType = typeWithIndex[0];
     const result = constructValueFromTsValue(tsValue, innerType);
@@ -371,20 +373,25 @@ function matchesType(value: any, type: Type): boolean {
       return value === undefined;
 
     case TypeKind.Type:
-        // TypeKind.Type is a generic type, we need to check if the value matches the type
-        if (type.isArray()) {
-            const typeArg = type.getTypeArguments?.()[0];
-            return Array.isArray(value) && value.every((item) => matchesType(item, typeArg));
-        } else if (type.isTuple()) {
-            const typeArgs = type.getTypeArguments?.();
-            return (
-            Array.isArray(value) &&
-            value.length === typeArgs.length &&
-            value.every((v, idx) => matchesType(v, typeArgs[idx]))
-            );
-        } else {
-            throw new Error(`Unsupported TypeKind.Type with generic type: ${type.displayName}`);
-        }
+      // TypeKind.Type is a generic type, we need to check if the value matches the type
+      if (type.isArray()) {
+        const typeArg = type.getTypeArguments?.()[0];
+        return (
+          Array.isArray(value) &&
+          value.every((item) => matchesType(item, typeArg))
+        );
+      } else if (type.isTuple()) {
+        const typeArgs = type.getTypeArguments?.();
+        return (
+          Array.isArray(value) &&
+          value.length === typeArgs.length &&
+          value.every((v, idx) => matchesType(v, typeArgs[idx]))
+        );
+      } else {
+        throw new Error(
+          `Unsupported TypeKind.Type with generic type: ${type.displayName}`,
+        );
+      }
 
     case TypeKind.ArrayBuffer:
       const elementType = type.getTypeArguments?.()[0];

--- a/golem-ts-sdk/src/mapping/values/ts-to-wit.ts
+++ b/golem-ts-sdk/src/mapping/values/ts-to-wit.ts
@@ -225,7 +225,7 @@ function handleUnion(tsValue: any, type: Type): Value {
   const typeWithIndex = findTypeOfAny(tsValue, possibleTypes);
 
   if (!typeWithIndex) {
-    throw new Error(`No matching type found for ${tsValue} in union type`);
+    throw new Error(`No matching type found for the value '${tsValue}' in union type. Type structure: ${unionType.displayName}`);
   } else {
     const innerType = typeWithIndex[0];
     const result = constructValueFromTsValue(tsValue, innerType);
@@ -367,6 +367,22 @@ function matchesType(value: any, type: Type): boolean {
 
     case TypeKind.Undefined:
       return value === undefined;
+
+    case TypeKind.Type:
+        // TypeKind.Type is a generic type, we need to check if the value matches the type
+        if (type.isArray()) {
+            const typeArg = type.getTypeArguments?.()[0];
+            return Array.isArray(value) && value.every((item) => matchesType(item, typeArg));
+        } else if (type.isTuple()) {
+            const typeArgs = type.getTypeArguments?.();
+            return (
+            Array.isArray(value) &&
+            value.length === typeArgs.length &&
+            value.every((v, idx) => matchesType(v, typeArgs[idx]))
+            );
+        } else {
+            throw new Error(`Unsupported TypeKind.Type with generic type: ${type.displayName}`);
+        }
 
     case TypeKind.ArrayBuffer:
       const elementType = type.getTypeArguments?.()[0];

--- a/golem-ts-sdk/src/mapping/values/ts-to-wit.ts
+++ b/golem-ts-sdk/src/mapping/values/ts-to-wit.ts
@@ -18,6 +18,8 @@ export function constructWitValueFromTsValue(
   return constructWitValueFromValue(value);
 }
 
+// Note that we take `type: Type` instead of `type: AnalysedType`(because at this point `AnalysedType` of the `tsValue` is also available)
+// as `Type` holds more information, and can be used to determine the error messages for wrong `tsValue` more accurately.
 function constructValueFromTsValue(tsValue: any, type: Type): Value {
   switch (type.kind) {
     case TypeKind.Null:

--- a/golem-ts-sdk/src/mapping/values/ts-to-wit.ts
+++ b/golem-ts-sdk/src/mapping/values/ts-to-wit.ts
@@ -405,6 +405,9 @@ function matchesType(value: any, type: Type): boolean {
     case TypeKind.ObjectType:
       return handleObjectMatch(value, type);
 
+    case TypeKind.Interface:
+      return handleObjectMatch(value, type);
+
     case TypeKind.Alias:
       const aliasType = type as TypeAliasType;
       const targetType = aliasType.target;

--- a/golem-ts-sdk/src/mapping/values/wit-to-ts.ts
+++ b/golem-ts-sdk/src/mapping/values/wit-to-ts.ts
@@ -12,6 +12,10 @@ import {
 import { WitValue } from 'golem:rpc/types@0.2.2';
 import { constructValueFromWitValue, Value } from './value';
 
+// Note that we take `expectedType: Type` instead of `expectedType: AnalysedType`(because at this point `AnalysedType` of the `witValue`
+// is also available) as `Type` holds more information, and help us have fine-grained control over the type conversion.
+// Hence, we need to use `Type` instead of `AnalysedType`. Note that the output of this function is a real ts-value,
+// and we need to ensure it is compatible with the `expectedType: Type`.
 export function constructTsValueFromWitValue(
   witValue: WitValue,
   expectedType: Type,

--- a/golem-ts-sdk/tests/arbitraries.ts
+++ b/golem-ts-sdk/tests/arbitraries.ts
@@ -65,7 +65,7 @@ export const unionComplexArb: fc.Arbitrary<UnionComplexType> = fc.oneof(
     fc.oneof(fc.integer(), fc.string(), fc.boolean(), objectArb),
     // listArb,
     // listComplexArb,
-    // tupleArb,
+    tupleArb,
     // tupleComplexArb,
     // mapArb,
     // fc.record({

--- a/golem-ts-sdk/tests/arbitraries.ts
+++ b/golem-ts-sdk/tests/arbitraries.ts
@@ -1,13 +1,14 @@
 import * as fc from 'fast-check';
 import {
-    ListComplexType,
-    ListType,
-    MapType, ObjectComplexType,
-    ObjectType,
-    TestInterfaceType,
-    TupleComplexType,
-    TupleType,
-    UnionType,
+  ListComplexType,
+  ListType,
+  MapType,
+  ObjectComplexType,
+  ObjectType,
+  TestInterfaceType,
+  TupleComplexType,
+  TupleType,
+  UnionType,
 } from './test-data';
 
 export const mapArb: fc.Arbitrary<MapType> = fc
@@ -23,58 +24,53 @@ export const objectArb: fc.Arbitrary<ObjectType> = fc.record({
 export const listArb: fc.Arbitrary<ListType> = fc.array(fc.string());
 
 export const listComplexArb: fc.Arbitrary<ListComplexType> = fc.array(
-    fc.record({
-        a: fc.string(),
-        b: fc.integer(),
-        c: fc.boolean(),
-    }),
-);
-
-export const unionArb: fc.Arbitrary<UnionType> = fc.oneof(
-    fc.integer(),
-    fc.string(),
-    fc.boolean(),
-    fc.record({
-        a: fc.string(),
-        b: fc.integer(),
-        c: fc.boolean(),
-    }),
-);
-
-export const tupleArb: fc.Arbitrary<TupleType> = fc.tuple(
-    fc.string(),
-    fc.integer(),
-    fc.boolean(),
-);
-
-export const tupleComplexArb: fc.Arbitrary<TupleComplexType> = fc.tuple(
-    fc.string(),
-    fc.integer(),
-    fc.record({
-        a: fc.string(),
-        b: fc.integer(),
-        c: fc.boolean(),
-    }),
-);
-
-export const objectComplexArb: fc.Arbitrary<ObjectComplexType> = fc.record({
+  fc.record({
     a: fc.string(),
     b: fc.integer(),
     c: fc.boolean(),
-    d: objectArb,
-    e: fc.oneof(
-        fc.integer(),
-        fc.string(),
-        fc.boolean(),
-        objectArb,
-    ),
-    f: listArb,
-    g: listComplexArb,
-    h: tupleArb,
-    i: tupleComplexArb,
-    j: mapArb,
-    k: fc.record({ n: fc.integer() }),
-})
+  }),
+);
+
+export const unionArb: fc.Arbitrary<UnionType> = fc.oneof(
+  fc.integer(),
+  fc.string(),
+  fc.boolean(),
+  fc.record({
+    a: fc.string(),
+    b: fc.integer(),
+    c: fc.boolean(),
+  }),
+);
+
+export const tupleArb: fc.Arbitrary<TupleType> = fc.tuple(
+  fc.string(),
+  fc.integer(),
+  fc.boolean(),
+);
+
+export const tupleComplexArb: fc.Arbitrary<TupleComplexType> = fc.tuple(
+  fc.string(),
+  fc.integer(),
+  fc.record({
+    a: fc.string(),
+    b: fc.integer(),
+    c: fc.boolean(),
+  }),
+);
+
+export const objectComplexArb: fc.Arbitrary<ObjectComplexType> = fc.record({
+  a: fc.string(),
+  b: fc.integer(),
+  c: fc.boolean(),
+  d: objectArb,
+  e: fc.oneof(fc.integer(), fc.string(), fc.boolean(), objectArb),
+  f: listArb,
+  g: listComplexArb,
+  h: tupleArb,
+  i: tupleComplexArb,
+  j: mapArb,
+  k: fc.record({ n: fc.integer() }),
+});
 
 export const interfaceArb: fc.Arbitrary<TestInterfaceType> = fc.record({
   bigintProp: fc.bigInt(),

--- a/golem-ts-sdk/tests/arbitraries.ts
+++ b/golem-ts-sdk/tests/arbitraries.ts
@@ -1,13 +1,13 @@
 import * as fc from 'fast-check';
 import {
-  ListObjectType,
-  ListType,
-  MapType,
-  ObjectType,
-  TestInterfaceType,
-  TupleComplexType,
-  TupleType,
-  UnionType,
+    ListComplexType,
+    ListType,
+    MapType, ObjectComplexType,
+    ObjectType,
+    TestInterfaceType,
+    TupleComplexType,
+    TupleType,
+    UnionType,
 } from './test-data';
 
 export const mapArb: fc.Arbitrary<MapType> = fc
@@ -22,52 +22,72 @@ export const objectArb: fc.Arbitrary<ObjectType> = fc.record({
 
 export const listArb: fc.Arbitrary<ListType> = fc.array(fc.string());
 
-export const listOfObjArb: fc.Arbitrary<ListObjectType> = fc.array(
-  fc.record({
-    a: fc.string(),
-    b: fc.integer(),
-    c: fc.boolean(),
-  }),
+export const listComplexArb: fc.Arbitrary<ListComplexType> = fc.array(
+    fc.record({
+        a: fc.string(),
+        b: fc.integer(),
+        c: fc.boolean(),
+    }),
 );
 
 export const unionArb: fc.Arbitrary<UnionType> = fc.oneof(
-  fc.integer(),
-  fc.string(),
-  fc.boolean(),
-  fc.record({
-    a: fc.string(),
-    b: fc.integer(),
-    c: fc.boolean(),
-  }),
+    fc.integer(),
+    fc.string(),
+    fc.boolean(),
+    fc.record({
+        a: fc.string(),
+        b: fc.integer(),
+        c: fc.boolean(),
+    }),
 );
 
 export const tupleArb: fc.Arbitrary<TupleType> = fc.tuple(
-  fc.string(),
-  fc.integer(),
-  fc.boolean(),
+    fc.string(),
+    fc.integer(),
+    fc.boolean(),
 );
 
 export const tupleComplexArb: fc.Arbitrary<TupleComplexType> = fc.tuple(
-  fc.string(),
-  fc.integer(),
-  fc.record({
+    fc.string(),
+    fc.integer(),
+    fc.record({
+        a: fc.string(),
+        b: fc.integer(),
+        c: fc.boolean(),
+    }),
+);
+
+export const objectComplexArb: fc.Arbitrary<ObjectComplexType> = fc.record({
     a: fc.string(),
     b: fc.integer(),
     c: fc.boolean(),
-  }),
-);
+    d: objectArb,
+    e: fc.oneof(
+        fc.integer(),
+        fc.string(),
+        fc.boolean(),
+        objectArb,
+    ),
+    f: listArb,
+    g: listComplexArb,
+    h: tupleArb,
+    i: tupleComplexArb,
+    j: mapArb,
+    k: fc.record({ n: fc.integer() }),
+})
 
 export const interfaceArb: fc.Arbitrary<TestInterfaceType> = fc.record({
   bigintProp: fc.bigInt(),
   booleanProp: fc.boolean(),
   falseProp: fc.constant(false),
-  listObjectProp: listOfObjArb,
+  listObjectProp: listComplexArb,
   listProp: listArb,
   mapProp: mapArb,
   nestedProp: fc.record({ n: fc.integer() }),
   nullProp: fc.constant(null),
   numberProp: fc.integer(),
   objectProp: objectArb,
+  objectComplexProp: objectComplexArb,
   stringProp: fc.string(),
   trueProp: fc.constant(true),
   tupleObjectProp: tupleComplexArb,

--- a/golem-ts-sdk/tests/arbitraries.ts
+++ b/golem-ts-sdk/tests/arbitraries.ts
@@ -7,7 +7,7 @@ import {
   ObjectType,
   TestInterfaceType,
   TupleComplexType,
-  TupleType,
+  TupleType, UnionComplexType,
   UnionType,
 } from './test-data';
 
@@ -58,6 +58,21 @@ export const tupleComplexArb: fc.Arbitrary<TupleComplexType> = fc.tuple(
   }),
 );
 
+export const unionComplexArb: fc.Arbitrary<UnionComplexType> = fc.oneof(
+    fc.integer(),
+    fc.string(),
+    fc.boolean(),
+    fc.oneof(fc.integer(), fc.string(), fc.boolean(), objectArb),
+    // listArb,
+    // listComplexArb,
+    // tupleArb,
+    // tupleComplexArb,
+    // mapArb,
+    // fc.record({
+    //   n: fc.integer(),
+    // }),
+);
+
 export const objectComplexArb: fc.Arbitrary<ObjectComplexType> = fc.record({
   a: fc.string(),
   b: fc.integer(),
@@ -89,5 +104,6 @@ export const interfaceArb: fc.Arbitrary<TestInterfaceType> = fc.record({
   tupleObjectProp: tupleComplexArb,
   tupleProp: tupleArb,
   unionProp: unionArb,
+  unionComplexProp: unionComplexArb,
   optionalProp: fc.option(fc.integer(), { nil: undefined }),
 });

--- a/golem-ts-sdk/tests/arbitraries.ts
+++ b/golem-ts-sdk/tests/arbitraries.ts
@@ -7,7 +7,8 @@ import {
   ObjectType,
   TestInterfaceType,
   TupleComplexType,
-  TupleType, UnionComplexType,
+  TupleType,
+  UnionComplexType,
   UnionType,
 } from './test-data';
 
@@ -59,18 +60,18 @@ export const tupleComplexArb: fc.Arbitrary<TupleComplexType> = fc.tuple(
 );
 
 export const unionComplexArb: fc.Arbitrary<UnionComplexType> = fc.oneof(
-    fc.integer(),
-    fc.string(),
-    fc.boolean(),
-    fc.oneof(fc.integer(), fc.string(), fc.boolean(), objectArb),
-    // listArb,
-    // listComplexArb,
-    tupleArb,
-    tupleComplexArb,
-    // mapArb,
-    fc.record({
-      n: fc.integer(),
-    }),
+  fc.integer(),
+  fc.string(),
+  fc.boolean(),
+  fc.oneof(fc.integer(), fc.string(), fc.boolean(), objectArb),
+  // listArb,
+  // listComplexArb,
+  tupleArb,
+  tupleComplexArb,
+  // mapArb,
+  fc.record({
+    n: fc.integer(),
+  }),
 );
 
 export const objectComplexArb: fc.Arbitrary<ObjectComplexType> = fc.record({

--- a/golem-ts-sdk/tests/arbitraries.ts
+++ b/golem-ts-sdk/tests/arbitraries.ts
@@ -66,7 +66,7 @@ export const unionComplexArb: fc.Arbitrary<UnionComplexType> = fc.oneof(
     // listArb,
     // listComplexArb,
     tupleArb,
-    // tupleComplexArb,
+    tupleComplexArb,
     // mapArb,
     // fc.record({
     //   n: fc.integer(),

--- a/golem-ts-sdk/tests/arbitraries.ts
+++ b/golem-ts-sdk/tests/arbitraries.ts
@@ -68,9 +68,9 @@ export const unionComplexArb: fc.Arbitrary<UnionComplexType> = fc.oneof(
     tupleArb,
     tupleComplexArb,
     // mapArb,
-    // fc.record({
-    //   n: fc.integer(),
-    // }),
+    fc.record({
+      n: fc.integer(),
+    }),
 );
 
 export const objectComplexArb: fc.Arbitrary<ObjectComplexType> = fc.record({

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -23,9 +23,23 @@ export type UnionType = number | string | boolean | ObjectType;
 
 export type ObjectType = { a: string; b: number; c: boolean };
 
+export type ObjectComplexType = {
+  a: string,
+  b: number,
+  c: boolean,
+  d: ObjectType,
+  e: UnionType,
+  f: ListType,
+  g: ListComplexType,
+  h: TupleType,
+  i: TupleComplexType,
+  j: MapType,
+  k: SimpleInterfaceType
+}
+
 export type ListType = Array<string>;
 
-export type ListObjectType = Array<ObjectType>;
+export type ListComplexType = Array<ObjectType>;
 
 export type TupleType = [string, number, boolean];
 
@@ -45,8 +59,9 @@ export interface TestInterfaceType {
   nestedProp: SimpleInterfaceType;
   unionProp: UnionType;
   objectProp: ObjectType;
+  objectComplexProp: ObjectComplexType;
   listProp: ListType;
-  listObjectProp: ListObjectType;
+  listObjectProp: ListComplexType;
   tupleProp: TupleType;
   tupleObjectProp: TupleComplexType;
   mapProp: MapType;

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -36,7 +36,7 @@ export type UnionComplexType =
    | TupleType
    | TupleComplexType
   // | MapType
-  // | SimpleInterfaceType;
+   | SimpleInterfaceType;
 
 export type ObjectType = { a: string; b: number; c: boolean };
 

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -31,12 +31,12 @@ export type UnionComplexType =
   | string
   | boolean
   | UnionType
-//  | ListType
+  //  | ListType
   // | ListComplexType
-   | TupleType
-   | TupleComplexType
+  | TupleType
+  | TupleComplexType
   // | MapType
-   | SimpleInterfaceType;
+  | SimpleInterfaceType;
 
 export type ObjectType = { a: string; b: number; c: boolean };
 

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -33,7 +33,7 @@ export type UnionComplexType =
   | UnionType
 //  | ListType
   // | ListComplexType
-  // | TupleType
+   | TupleType
   // | TupleComplexType
   // | MapType
   // | SimpleInterfaceType;

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -24,18 +24,18 @@ export type UnionType = number | string | boolean | ObjectType;
 export type ObjectType = { a: string; b: number; c: boolean };
 
 export type ObjectComplexType = {
-  a: string,
-  b: number,
-  c: boolean,
-  d: ObjectType,
-  e: UnionType,
-  f: ListType,
-  g: ListComplexType,
-  h: TupleType,
-  i: TupleComplexType,
-  j: MapType,
-  k: SimpleInterfaceType
-}
+  a: string;
+  b: number;
+  c: boolean;
+  d: ObjectType;
+  e: UnionType;
+  f: ListType;
+  g: ListComplexType;
+  h: TupleType;
+  i: TupleComplexType;
+  j: MapType;
+  k: SimpleInterfaceType;
+};
 
 export type ListType = Array<string>;
 

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -34,7 +34,7 @@ export type UnionComplexType =
 //  | ListType
   // | ListComplexType
    | TupleType
-  // | TupleComplexType
+   | TupleComplexType
   // | MapType
   // | SimpleInterfaceType;
 

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -65,18 +65,18 @@ export interface TestInterfaceType {
   tupleProp: TupleType;
   tupleObjectProp: TupleComplexType;
   mapProp: MapType;
-  //FIXME, RTTIST bug or not supported yet
+  // FIXME, `RTTIST` bug or not supported yet
   // mapAlternativeProp: MapTypeAlternative,
-  //unionPropInlined: string | number;
+  // unionPropInlined: string | number;
   // recordProp: RecordType;
   // enumType: EnumTypeAlias;
-  //enumTypeInlined: EnumType,
+  // enumTypeInlined: EnumType,
   // objectPropInlined: {
   //     a: string,
   //     b: number,
   //     c: boolean
   // }
-  //enumProp: EnumTypeAlias,
+  // enumProp: EnumTypeAlias,
   // enumPropInlined: EnumTypeAlias,
 }
 

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -25,6 +25,19 @@ interface SimpleInterfaceType {
 // type MyUnion = MyNumber | MyString;
 export type UnionType = number | string | boolean | ObjectType;
 
+// Deliberately adding duplicate types since TypeScript allows it
+export type UnionComplexType =
+  | number
+  | string
+  | boolean
+  | UnionType
+//  | ListType
+  // | ListComplexType
+  // | TupleType
+  // | TupleComplexType
+  // | MapType
+  // | SimpleInterfaceType;
+
 export type ObjectType = { a: string; b: number; c: boolean };
 
 export type ObjectComplexType = {
@@ -62,6 +75,7 @@ export interface TestInterfaceType {
   optionalProp?: number;
   nestedProp: SimpleInterfaceType;
   unionProp: UnionType;
+  unionComplexProp: UnionComplexType;
   objectProp: ObjectType;
   objectComplexProp: ObjectComplexType;
   listProp: ListType;

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -16,9 +16,13 @@ interface SimpleInterfaceType {
   n: number;
 }
 
-// A union type will become a variant in WIT, and the names will be available in the case.name
-// Example: [{name: 'string', typ: { kind: 'string' }}, {name: 'number', typ: { kind: 's32' }}]
-// This needs to be verified with @vigoo
+// A union type will become a variant in WIT, however the names are of the type names (which is wrong)
+// but I can't figure any other way of naming it unless it affect the user such as always do an alias
+// i.e, instead of type MyUnion = `number | string`
+// they have to write it as
+// type MyNumber = number;
+// type MyString = string;
+// type MyUnion = MyNumber | MyString;
 export type UnionType = number | string | boolean | ObjectType;
 
 export type ObjectType = { a: string; b: number; c: boolean };

--- a/golem-ts-sdk/tests/type.mapping.test.ts
+++ b/golem-ts-sdk/tests/type.mapping.test.ts
@@ -317,7 +317,9 @@ function checkMapFields(fields: any[]) {
 }
 
 function checkObjectComplexFields(fields: any[]) {
-  const objectFields = fields.filter((f) => f.name.startsWith('objectComplexProp'));
+  const objectFields = fields.filter((f) =>
+    f.name.startsWith('objectComplexProp'),
+  );
   expect(objectFields.length).toBeGreaterThan(0);
 
   const expected = [
@@ -402,11 +404,7 @@ function checkObjectComplexFields(fields: any[]) {
       typ: {
         kind: 'tuple',
         value: {
-          items: [
-            { kind: 'string' },
-            { kind: 's32' },
-            { kind: 'bool' },
-          ],
+          items: [{ kind: 'string' }, { kind: 's32' }, { kind: 'bool' }],
           name: undefined,
         },
       },
@@ -443,10 +441,7 @@ function checkObjectComplexFields(fields: any[]) {
           inner: {
             kind: 'tuple',
             value: {
-              items: [
-                { kind: 'string' },
-                { kind: 's32' },
-              ],
+              items: [{ kind: 'string' }, { kind: 's32' }],
               name: undefined,
             },
           },
@@ -459,9 +454,7 @@ function checkObjectComplexFields(fields: any[]) {
       typ: {
         kind: 'record',
         value: {
-          fields: [
-            { name: 'n', typ: { kind: 's32' } },
-          ],
+          fields: [{ name: 'n', typ: { kind: 's32' } }],
           name: undefined,
         },
       },

--- a/golem-ts-sdk/tests/type.mapping.test.ts
+++ b/golem-ts-sdk/tests/type.mapping.test.ts
@@ -37,6 +37,7 @@ describe('TypeScript Interface to AnalysedType', () => {
 
   it('Object types within an interface', () => {
     checkObjectFields(recordFields);
+    checkObjectComplexFields(recordFields);
   });
 
   it('List type within an interface', () => {
@@ -312,5 +313,163 @@ function checkMapFields(fields: any[]) {
       expect(inner.value.items[0].kind).toBe('string');
       expect(inner.value.items[1].kind).toBe('s32');
     }
+  });
+}
+
+function checkObjectComplexFields(fields: any[]) {
+  const objectFields = fields.filter((f) => f.name.startsWith('objectComplexProp'));
+  expect(objectFields.length).toBeGreaterThan(0);
+
+  const expected = [
+    { name: 'a', typ: { kind: 'string' } },
+    { name: 'b', typ: { kind: 's32' } },
+    { name: 'c', typ: { kind: 'bool' } },
+    {
+      name: 'd',
+      typ: {
+        kind: 'record',
+        value: {
+          fields: [
+            { name: 'a', typ: { kind: 'string' } },
+            { name: 'b', typ: { kind: 's32' } },
+            { name: 'c', typ: { kind: 'bool' } },
+          ],
+          name: undefined,
+        },
+      },
+    },
+    {
+      name: 'e',
+      typ: {
+        kind: 'variant',
+        value: {
+          cases: [
+            { name: 'string', typ: { kind: 'string' } },
+            { name: 'number', typ: { kind: 's32' } },
+            { name: 'false', typ: { kind: 'bool' } },
+            { name: 'true', typ: { kind: 'bool' } },
+            {
+              name: 'objecttype',
+              typ: {
+                kind: 'record',
+                value: {
+                  fields: [
+                    { name: 'a', typ: { kind: 'string' } },
+                    { name: 'b', typ: { kind: 's32' } },
+                    { name: 'c', typ: { kind: 'bool' } },
+                  ],
+                  name: undefined,
+                },
+              },
+            },
+          ],
+          name: undefined,
+        },
+      },
+    },
+    {
+      name: 'f',
+      typ: {
+        kind: 'list',
+        value: {
+          inner: { kind: 'string' },
+          name: undefined,
+        },
+      },
+    },
+    {
+      name: 'g',
+      typ: {
+        kind: 'list',
+        value: {
+          inner: {
+            kind: 'record',
+            value: {
+              fields: [
+                { name: 'a', typ: { kind: 'string' } },
+                { name: 'b', typ: { kind: 's32' } },
+                { name: 'c', typ: { kind: 'bool' } },
+              ],
+              name: undefined,
+            },
+          },
+          name: undefined,
+        },
+      },
+    },
+    {
+      name: 'h',
+      typ: {
+        kind: 'tuple',
+        value: {
+          items: [
+            { kind: 'string' },
+            { kind: 's32' },
+            { kind: 'bool' },
+          ],
+          name: undefined,
+        },
+      },
+    },
+    {
+      name: 'i',
+      typ: {
+        kind: 'tuple',
+        value: {
+          items: [
+            { kind: 'string' },
+            { kind: 's32' },
+            {
+              kind: 'record',
+              value: {
+                fields: [
+                  { name: 'a', typ: { kind: 'string' } },
+                  { name: 'b', typ: { kind: 's32' } },
+                  { name: 'c', typ: { kind: 'bool' } },
+                ],
+                name: undefined,
+              },
+            },
+          ],
+          name: undefined,
+        },
+      },
+    },
+    {
+      name: 'j',
+      typ: {
+        kind: 'list',
+        value: {
+          inner: {
+            kind: 'tuple',
+            value: {
+              items: [
+                { kind: 'string' },
+                { kind: 's32' },
+              ],
+              name: undefined,
+            },
+          },
+          name: undefined,
+        },
+      },
+    },
+    {
+      name: 'k',
+      typ: {
+        kind: 'record',
+        value: {
+          fields: [
+            { name: 'n', typ: { kind: 's32' } },
+          ],
+          name: undefined,
+        },
+      },
+    },
+  ];
+
+  objectFields.forEach((field) => {
+    expect(field.typ.kind).toBe('record');
+    expect(field.typ.value.fields).toEqual(expected);
   });
 }

--- a/golem-ts-sdk/tests/utils.ts
+++ b/golem-ts-sdk/tests/utils.ts
@@ -4,7 +4,7 @@ import { Type } from 'rttist';
 import './setup';
 import { AnalysedType, NameTypePair } from '../src/mapping/types/analysed-type';
 import { expect } from 'vitest';
-import { ListObjectType } from './test-data';
+import { ListComplexType } from './test-data';
 
 export function getAll() {
   return Metadata.getTypes().filter(
@@ -29,7 +29,7 @@ export function getTestListType(): Type {
 }
 
 export function getTestListOfObjectType(): Type {
-  return fetchType('ListObjectType');
+  return fetchType('ListComplexType');
 }
 
 export function getUnionType(): Type {

--- a/golem-ts-sdk/tests/utils.ts
+++ b/golem-ts-sdk/tests/utils.ts
@@ -36,6 +36,10 @@ export function getUnionType(): Type {
   return fetchType('UnionType');
 }
 
+export function getUnionComplexType(): Type {
+  return fetchType('UnionComplexType');
+}
+
 export function getTupleType(): Type {
   return fetchType('TupleType');
 }

--- a/golem-ts-sdk/tests/value.mapping.test.ts
+++ b/golem-ts-sdk/tests/value.mapping.test.ts
@@ -101,7 +101,7 @@ describe('typescript value to wit value round-trip conversions', () => {
         d: {
           a: '',
           b: 0,
-          c: false
+          c: false,
         },
         e: '',
         f: [],
@@ -151,7 +151,7 @@ describe('typescript value to wit value round-trip conversions', () => {
         d: {
           a: '',
           b: 0,
-          c: false
+          c: false,
         },
         e: '',
         f: [],
@@ -193,7 +193,7 @@ describe('typescript value to wit value round-trip conversions', () => {
         d: {
           a: '',
           b: 0,
-          c: false
+          c: false,
         },
         e: '',
         f: [],

--- a/golem-ts-sdk/tests/value.mapping.test.ts
+++ b/golem-ts-sdk/tests/value.mapping.test.ts
@@ -111,6 +111,7 @@ describe('typescript value to wit value round-trip conversions', () => {
         j: new Map<string, number>(),
         k: { n: 0 },
       },
+      unionComplexProp: 1,
       nullProp: null,
       numberProp: 0,
       objectProp: { a: '', b: 0, c: false },
@@ -144,6 +145,7 @@ describe('typescript value to wit value round-trip conversions', () => {
       tupleProp: ['', 0, false],
       unionProp: 1,
       optionalProp: 2,
+      unionComplexProp: 1,
       objectComplexProp: {
         a: '',
         b: 0,
@@ -186,6 +188,7 @@ describe('typescript value to wit value round-trip conversions', () => {
       tupleProp: ['', 0, false],
       unionProp: { a: 'test', b: 42, c: true }, // Using an object as a union type
       optionalProp: 2,
+      unionComplexProp: 1,
       objectComplexProp: {
         a: '',
         b: 0,

--- a/golem-ts-sdk/tests/value.mapping.test.ts
+++ b/golem-ts-sdk/tests/value.mapping.test.ts
@@ -20,7 +20,7 @@ import {
   listArb,
   mapArb,
   objectArb,
-  listOfObjArb,
+  listComplexArb,
   tupleComplexArb,
   tupleArb,
 } from './arbitraries';
@@ -66,7 +66,7 @@ describe('typescript value to wit value round-trip conversions', () => {
 
   it('should correctly perform round-trip conversion for arbitrary values of list of object type', () => {
     fc.assert(
-      fc.property(listOfObjArb, (arbData) => {
+      fc.property(listComplexArb, (arbData) => {
         const type = getTestListOfObjectType();
         runRoundTripTest(arbData, type);
       }),
@@ -94,6 +94,23 @@ describe('typescript value to wit value round-trip conversions', () => {
       listProp: [],
       mapProp: new Map<string, number>(),
       nestedProp: { n: 0 },
+      objectComplexProp: {
+        a: '',
+        b: 0,
+        c: false,
+        d: {
+          a: '',
+          b: 0,
+          c: false
+        },
+        e: '',
+        f: [],
+        g: [],
+        h: ['', 0, false],
+        i: ['', 0, { a: '', b: 0, c: false }],
+        j: new Map<string, number>(),
+        k: { n: 0 },
+      },
       nullProp: null,
       numberProp: 0,
       objectProp: { a: '', b: 0, c: false },
@@ -127,6 +144,23 @@ describe('typescript value to wit value round-trip conversions', () => {
       tupleProp: ['', 0, false],
       unionProp: 1,
       optionalProp: 2,
+      objectComplexProp: {
+        a: '',
+        b: 0,
+        c: false,
+        d: {
+          a: '',
+          b: 0,
+          c: false
+        },
+        e: '',
+        f: [],
+        g: [],
+        h: ['', 0, false],
+        i: ['', 0, { a: '', b: 0, c: false }],
+        j: new Map<string, number>(),
+        k: { n: 0 },
+      },
     };
 
     const type = getTestInterfaceType();
@@ -152,6 +186,23 @@ describe('typescript value to wit value round-trip conversions', () => {
       tupleProp: ['', 0, false],
       unionProp: { a: 'test', b: 42, c: true }, // Using an object as a union type
       optionalProp: 2,
+      objectComplexProp: {
+        a: '',
+        b: 0,
+        c: false,
+        d: {
+          a: '',
+          b: 0,
+          c: false
+        },
+        e: '',
+        f: [],
+        g: [],
+        h: ['', 0, false],
+        i: ['', 0, { a: '', b: 0, c: false }],
+        j: new Map<string, number>(),
+        k: { n: 0 },
+      },
     };
 
     const type = getTestInterfaceType();

--- a/golem-ts-sdk/tests/value.mapping.test.ts
+++ b/golem-ts-sdk/tests/value.mapping.test.ts
@@ -7,6 +7,8 @@ import {
   getTestListOfObjectType,
   getTupleComplexType,
   getTupleType,
+  getUnionType,
+  getUnionComplexType,
 } from './utils';
 import { TestInterfaceType } from './test-data';
 import {
@@ -23,6 +25,8 @@ import {
   listComplexArb,
   tupleComplexArb,
   tupleArb,
+  unionArb,
+  unionComplexArb,
 } from './arbitraries';
 import * as fc from 'fast-check';
 import { Type } from 'rttist';
@@ -79,8 +83,20 @@ describe('typescript value to wit value round-trip conversions', () => {
         const simpleType = getTupleType();
         runRoundTripTest(tupleData, simpleType);
 
-        const type = getTupleComplexType();
-        runRoundTripTest(tupleComplexData, type);
+        const complexType = getTupleComplexType();
+        runRoundTripTest(tupleComplexData, complexType);
+      }),
+    );
+  });
+
+  it('should correctly perform round-trip conversion for arbitrary values of union', () => {
+    fc.assert(
+      fc.property(unionArb, unionComplexArb, (unionData, unionComplexData) => {
+        const simpleType = getUnionType();
+        runRoundTripTest(unionData, simpleType);
+
+        const complexType = getUnionComplexType();
+        runRoundTripTest(unionComplexData, complexType);
       }),
     );
   });


### PR DESCRIPTION
This PR handles objects having complex objects within as property based tests, and same for union

There are some types that didn't pass tests. Which is having a list within Union. I will fix it separately as a different PR.