### PR TITLE
Use Either

### DIFF
--- a/golem-ts-sdk/src/index.ts
+++ b/golem-ts-sdk/src/index.ts
@@ -26,7 +26,7 @@ export { BaseAgent } from './base-agent';
 export { AgentId } from './agent-id';
 export { prompt, description, agent } from './decorators';
 export { Metadata } from './type_metadata';
-export { Result } from './new-types/result';
+export { Either } from './new-types/either';
 
 /// Registry
 export const agents = new Map<AgentId, Agent>();

--- a/golem-ts-sdk/src/mapping/types/inbuilt.ts
+++ b/golem-ts-sdk/src/mapping/types/inbuilt.ts
@@ -4,6 +4,6 @@ export function isInBuiltResult(type: Type): boolean {
     const genericType = type as GenericType<typeof type>;
     const typeDef = genericType.genericTypeDefinition;
 
-    return typeDef.name === 'Result' && typeDef.id === '@@golemcloud/golem-ts-sdk/src/new-types/result:Result'
+    return typeDef.name === 'Either' && typeDef.id.startsWith("@@golemcloud/golem-ts-sdk")
 }
 

--- a/golem-ts-sdk/src/new-types/either.ts
+++ b/golem-ts-sdk/src/new-types/either.ts
@@ -1,7 +1,7 @@
 // A few new types that can be used instead of data types such as Effect.Either
 
 /**
- * A simple Result type that can be used to represent success or failure.
+ * A simple Either type that can be used to represent success or failure.
  * It is similar to Effect.Either. This is exposed as data types such as Effect.Either
  * are not supported by golem-ts-sdk.
  *

--- a/golem-ts-sdk/src/new-types/either.ts
+++ b/golem-ts-sdk/src/new-types/either.ts
@@ -8,13 +8,13 @@
  * SDK developer note: `namespace` cannot be used in the SDK, as it is not supported by RTTIST.
  * Hence, functionalities such as `map`, `mapBoth` are not under the namespace `Result` as in Effect.Either.
  */
-export type Result<T, E> = { tag: 'ok'; val: T } | { tag: 'err'; val: E };
+export type Either<T, E> = { tag: 'ok'; val: T } | { tag: 'err'; val: E };
 
 /**
  * Creates a Result with a successful value.
  * @param val
  */
-function ok<T, E = never>(val: T): Result<T, E> {
+function ok<T, E = never>(val: T): Either<T, E> {
   return { tag: 'ok', val };
 }
 
@@ -22,7 +22,7 @@ function ok<T, E = never>(val: T): Result<T, E> {
  * Creates a Result with an error value.
  * @param val
  */
-function err<T = never, E = unknown>(val: E): Result<T, E> {
+function err<T = never, E = unknown>(val: E): Either<T, E> {
   return { tag: 'err', val };
 }
 
@@ -32,7 +32,7 @@ function err<T = never, E = unknown>(val: E): Result<T, E> {
  * @param r The Result to map.
  * @param f The function to apply to the value if it is 'ok'.
  */
-function map<T, E, U>(r: Result<T, E>, f: (t: T) => U): Result<U, E> {
+function map<T, E, U>(r: Either<T, E>, f: (t: T) => U): Either<U, E> {
   return r.tag === 'ok' ? ok(f(r.val)) : r;
 }
 
@@ -44,10 +44,10 @@ function map<T, E, U>(r: Result<T, E>, f: (t: T) => U): Result<U, E> {
  * @param onErr The function to apply to the error if it is 'err'.
  */
 function mapBoth<T, E, U, F>(
-  r: Result<T, E>,
+  r: Either<T, E>,
   onOk: (t: T) => U,
   onErr: (e: E) => F,
-): Result<U, F> {
+): Either<U, F> {
   return r.tag === 'ok' ? ok(onOk(r.val)) : err(onErr(r.val));
 }
 
@@ -58,14 +58,14 @@ function mapBoth<T, E, U, F>(
  * @param rb The second Result.
  */
 function zipBoth<A, B, E>(
-  ra: Result<A, E>,
-  rb: Result<B, E>,
-): Result<[A, B], E> {
+  ra: Either<A, E>,
+  rb: Either<B, E>,
+): Either<[A, B], E> {
   if (ra.tag === 'err') {
-    return { tag: 'err', val: ra.val } as Result<[A, B], E>;
+    return { tag: 'err', val: ra.val } as Either<[A, B], E>;
   }
   if (rb.tag === 'err') {
-    return { tag: 'err', val: rb.val } as Result<[A, B], E>;
+    return { tag: 'err', val: rb.val } as Either<[A, B], E>;
   }
   return ok([ra.val, rb.val]);
 }
@@ -75,7 +75,7 @@ function zipBoth<A, B, E>(
  * If any Result is 'err', it returns that error.
  * @param results An array of Results to combine.
  */
-function allResults<T, E>(results: Result<T, E>[]): Result<T[], E> {
+function allResults<T, E>(results: Either<T, E>[]): Either<T[], E> {
   const vals: T[] = [];
   for (const r of results) {
     if (r.tag === 'err') return r;

--- a/golem-ts-sdk/tests/test-data.ts
+++ b/golem-ts-sdk/tests/test-data.ts
@@ -11,7 +11,7 @@
 // functions in type-utils.ts in tests module.
 
 // ─────────────────────────────────────────────────────────────────────────────
-import { Result } from '../src/new-types/result';
+import { Either } from '../src/new-types/either';
 
 interface SimpleInterfaceType {
   n: number;
@@ -67,7 +67,7 @@ export type ObjectComplexType = {
   i: TupleComplexType;
   j: MapType;
   k: SimpleInterfaceType;
-  l: Result<number, string>;
+  l: Either<number, string>;
   //m: Either.Either<number, string> // FIXME: Effect.Either is inferred as Invalid by RTTIST
 };
 


### PR DESCRIPTION
We expose an `Either` as users cannot use data types like `Either` from effect.
This is based on my own experience dealing withe error handling in type-script, and given user will have hard time depending on `effect` library, we have to expose at least this much