### PR TITLE
Add tests for registry

### DIFF
--- a/golem-ts-sdk/src/index.ts
+++ b/golem-ts-sdk/src/index.ts
@@ -66,13 +66,13 @@ async function initialize(
 
   if (Option.isNone(initiator)) {
     const entries = Array.from(AgentInitiatorRegistry.entries()).map(
-      (entry) => entry[0],
+      (entry) => entry[0].value,
     );
 
     return {
       tag: 'err',
       val: createCustomError(
-        `No implementation found for agent: ${agentType}. Valid entries are ${entries.join(', ')}`,
+        `Invalid agent'${agentType}'. Valid agents are ${entries.join(', ')}`,
       ),
     };
   }

--- a/golem-ts-sdk/src/internal/registry/agentInitiatorRegistry.ts
+++ b/golem-ts-sdk/src/internal/registry/agentInitiatorRegistry.ts
@@ -16,21 +16,29 @@ import * as Option from 'effect/Option';
 import { AgentInitiator } from '../agentInitiator';
 import { AgentTypeName } from '../../newTypes/agentTypeName';
 
-// Although only 1 agent can exist max in a container,
-// the container still keeps track of initiators of all agent classes
-// in the user code
-const agentInitiators = new Map<AgentTypeName, AgentInitiator>();
+// Although only 1 agent instance can exist max in a container,
+// the container will end up keeping track of initiators of all agent classes
+// in the user code for obvious reasons
+const agentInitiators = new Map<string, AgentInitiator>();
 
 export const AgentInitiatorRegistry = {
   register(agentName: AgentTypeName, agentInitiator: AgentInitiator): void {
-    agentInitiators.set(agentName, agentInitiator);
+    agentInitiators.set(agentName.value, agentInitiator);
   },
 
   lookup(agentName: AgentTypeName): Option.Option<AgentInitiator> {
-    return Option.fromNullable(agentInitiators.get(agentName));
+    return Option.fromNullable(agentInitiators.get(agentName.value));
   },
 
   entries(): IterableIterator<[AgentTypeName, AgentInitiator]> {
-    return agentInitiators.entries();
+    return Array.from(agentInitiators.entries())
+      .map(
+        ([name, initiator]) =>
+          [new AgentTypeName(name), initiator] as [
+            AgentTypeName,
+            AgentInitiator,
+          ],
+      )
+      [Symbol.iterator]();
   },
 };

--- a/golem-ts-sdk/src/internal/registry/agentMethodMetadataRegistry.ts
+++ b/golem-ts-sdk/src/internal/registry/agentMethodMetadataRegistry.ts
@@ -14,24 +14,27 @@
 
 import { AgentClassName } from '../../newTypes/agentClassName';
 
+type AgentClassNameString = string;
+type AgentMethodNameString = string;
+
 const agentMethodMetadataRegistry = new Map<
-  AgentClassName,
-  Map<string, { prompt?: string; description?: string }>
+  AgentClassNameString,
+  Map<AgentMethodNameString, { prompt?: string; description?: string }>
 >();
 
 export const AgentMethodMetadataRegistry = {
   ensureMeta(agentClassName: AgentClassName, method: string) {
-    if (!agentMethodMetadataRegistry.has(agentClassName)) {
-      agentMethodMetadataRegistry.set(agentClassName, new Map());
+    if (!agentMethodMetadataRegistry.has(agentClassName.value)) {
+      agentMethodMetadataRegistry.set(agentClassName.value, new Map());
     }
-    const classMeta = agentMethodMetadataRegistry.get(agentClassName)!;
+    const classMeta = agentMethodMetadataRegistry.get(agentClassName.value)!;
     if (!classMeta.has(method)) {
       classMeta.set(method, {});
     }
   },
 
   lookup(agentClassName: AgentClassName) {
-    return agentMethodMetadataRegistry.get(agentClassName);
+    return agentMethodMetadataRegistry.get(agentClassName.value);
   },
 
   setPromptName(
@@ -40,7 +43,7 @@ export const AgentMethodMetadataRegistry = {
     prompt: string,
   ) {
     AgentMethodMetadataRegistry.ensureMeta(agentClassName, method);
-    const classMeta = agentMethodMetadataRegistry.get(agentClassName)!;
+    const classMeta = agentMethodMetadataRegistry.get(agentClassName.value)!;
     classMeta.get(method)!.prompt = prompt;
   },
 
@@ -50,7 +53,7 @@ export const AgentMethodMetadataRegistry = {
     description: string,
   ) {
     AgentMethodMetadataRegistry.ensureMeta(agentClassName, method);
-    const classMeta = agentMethodMetadataRegistry.get(agentClassName)!;
+    const classMeta = agentMethodMetadataRegistry.get(agentClassName.value)!;
     classMeta.get(method)!.description = description;
   },
 };

--- a/golem-ts-sdk/src/internal/registry/agentTypeRegistry.ts
+++ b/golem-ts-sdk/src/internal/registry/agentTypeRegistry.ts
@@ -15,16 +15,25 @@
 import { AgentType } from 'golem:agent/common';
 import { AgentClassName } from '../../newTypes/agentClassName';
 import * as Option from 'effect/Option';
+import { AgentTypeName } from '../../newTypes/agentTypeName';
+import { AgentInitiator } from '../agentInitiator';
 
-const agentTypeRegistry = new Map<AgentClassName, AgentType>();
+type AgentClassNameString = string;
+
+const agentTypeRegistry = new Map<AgentClassNameString, AgentType>();
 
 export const AgentTypeRegistry = {
   register(agentClassName: AgentClassName, agentType: AgentType): void {
-    agentTypeRegistry.set(agentClassName, agentType);
+    agentTypeRegistry.set(agentClassName.value, agentType);
   },
 
   entries(): IterableIterator<[AgentClassName, AgentType]> {
-    return agentTypeRegistry.entries();
+    return Array.from(agentTypeRegistry.entries())
+      .map(
+        ([name, agentType]) =>
+          [new AgentClassName(name), agentType] as [AgentClassName, AgentType],
+      )
+      [Symbol.iterator]();
   },
 
   getRegisteredAgents(): AgentType[] {
@@ -32,10 +41,10 @@ export const AgentTypeRegistry = {
   },
 
   lookup(agentClassName: AgentClassName): Option.Option<AgentType> {
-    return Option.fromNullable(agentTypeRegistry.get(agentClassName));
+    return Option.fromNullable(agentTypeRegistry.get(agentClassName.value));
   },
 
   exists(agentClassName: AgentClassName): boolean {
-    return agentTypeRegistry.has(agentClassName);
+    return agentTypeRegistry.has(agentClassName.value);
   },
 };

--- a/golem-ts-sdk/tests/registry.test.ts
+++ b/golem-ts-sdk/tests/registry.test.ts
@@ -1,0 +1,113 @@
+// Copyright 2024-2025 Golem Cloud
+//
+// Licensed under the Golem Source License v1.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+import { AgentTypeName } from '../src/newTypes/agentTypeName';
+import { AgentClassName } from '../src';
+import { AgentInitiatorRegistry } from '../src/internal/registry/agentInitiatorRegistry';
+import { Result } from 'golem:rpc/types@0.2.2';
+import { ResolvedAgent } from '../src/internal/resolvedAgent';
+import { AgentError, AgentType, DataValue } from 'golem:agent/common';
+import { AgentInitiator } from '../src/internal/agentInitiator';
+import * as Option from 'effect/Option';
+import { AgentTypeRegistry } from '../src/internal/registry/agentTypeRegistry';
+import { AgentMethodMetadataRegistry } from '../src/internal/registry/agentMethodMetadataRegistry';
+
+describe('AgentType look up', () => {
+  it('AgentInitiatorRegistry should return the initiator when looking up by string representation of agentType', () => {
+    const agentClassName = new AgentClassName('AssistantAgent');
+    const agentTypeName = AgentTypeName.fromAgentClassName(agentClassName);
+
+    const FailingAgentInitiator: AgentInitiator = {
+      initiate: (
+        _agentName: string,
+        _constructorParams: DataValue,
+      ): Result<ResolvedAgent, AgentError> => {
+        return {
+          tag: 'err',
+          val: {
+            tag: 'invalid-agent-id',
+            val: 'unimplemented',
+          },
+        };
+      },
+    };
+
+    AgentInitiatorRegistry.register(agentTypeName, FailingAgentInitiator);
+
+    console.log(AgentInitiatorRegistry.entries());
+
+    const lookupResult = AgentInitiatorRegistry.lookup(
+      new AgentTypeName('assistant-agent'),
+    );
+
+    expect(lookupResult).toEqual(Option.some(FailingAgentInitiator));
+  });
+
+  it('AgentTypeRegistry should return the agent-type when looking up by string representation of agentClassName', () => {
+    const agentClassName = new AgentClassName('AssistantAgent');
+    const agentTypeName = AgentTypeName.fromAgentClassName(agentClassName);
+    const AgentTypeSample: AgentType = {
+      typeName: agentTypeName.value,
+      description: 'An assistant agent',
+      constructor: {
+        name: 'foo',
+        description: 'sample desc',
+        promptHint: 'bar',
+        inputSchema: {
+          tag: 'tuple',
+          val: [],
+        },
+      },
+      methods: [],
+      dependencies: [],
+    };
+
+    AgentTypeRegistry.register(agentClassName, AgentTypeSample);
+
+    const lookupResult = AgentTypeRegistry.lookup(
+      new AgentClassName('AssistantAgent'),
+    );
+
+    expect(lookupResult).toEqual(Option.some(AgentTypeSample));
+  });
+
+  it('AgentMethodMetadataRegistry should return method details when looking up by string representation of agentClassName', () => {
+    const agentClassName = new AgentClassName('AssistantAgent');
+
+    AgentMethodMetadataRegistry.setDescription(
+      agentClassName,
+      'foo',
+      'sample desc',
+    );
+
+    AgentMethodMetadataRegistry.setPromptName(
+      agentClassName,
+      'foo',
+      'sample prompt',
+    );
+
+    const lookupResult = AgentMethodMetadataRegistry.lookup(
+      new AgentClassName('AssistantAgent'),
+    );
+
+    expect(lookupResult?.size).toEqual(1);
+
+    const prompt = lookupResult?.get('foo')?.prompt;
+    const description = lookupResult?.get('foo')?.description;
+
+    expect(prompt).toEqual('sample prompt');
+    expect(description).toEqual('sample desc');
+  });
+});


### PR DESCRIPTION
There is no agent-instance registry anymore, because there can be only 1 agent instance in a container.
But we still have initiator registry, metadata registry that were not backed by tests.

Adding some _obvious looking_ tests, because just a small refactor in typescript can break things. Exmaple map-keys are looked up by reference and not value etc. 