### PR TITLE
Avoid user code depend on golem-ts-types directly

### DIFF
--- a/golem-ts-sdk/package.json
+++ b/golem-ts-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@golemcloud/golem-ts-sdk",
   "type": "module",
-  "version": "0.0.1-dev.28",
+  "version": "0.0.1-dev.29",
   "publishConfig": {
     "access": "public",
     "tag": "test"

--- a/golem-ts-sdk/package.json
+++ b/golem-ts-sdk/package.json
@@ -40,7 +40,7 @@
     "generate-test-types-metadata": "npx golem-typegen ./tsconfig.json --files tests/**/*.ts",
     "prebuild": "npm run clean-test-data && npm run generate-dts && npm run generate-test-types-metadata",
     "build": "tsc --noEmit && rollup -c",
-    "test": "npm run build && vitest run",
+    "test": "npm run clean-test-data && npm run generate-test-types-metadata && tsc --noEmit && vitest run",
     "dev": "rollup -c -w"
   },
   "keywords": [],

--- a/golem-ts-sdk/src/index.ts
+++ b/golem-ts-sdk/src/index.ts
@@ -28,7 +28,9 @@ export { prompt, description, agent } from './decorators';
 export * from './newTypes/either';
 export * from './newTypes/agentClassName';
 export * from './newTypes/textInput';
+
 export { AgentClassName } from './newTypes/agentClassName';
+export { TypescriptTypeRegistry } from './typescriptTypeRegistry';
 
 let resolvedAgent: Option.Option<ResolvedAgent> = Option.none();
 

--- a/golem-ts-sdk/src/typescriptTypeRegistry.ts
+++ b/golem-ts-sdk/src/typescriptTypeRegistry.ts
@@ -1,0 +1,24 @@
+// Copyright 2024-2025 Golem Cloud
+//
+// Licensed under the Golem Source License v1.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A wrapper over golem-ts-types-core/TypeMetadata to be used from user's code
+// for them to register its types with the SDk.
+
+import { TypeMetadata } from '@golemcloud/golem-ts-types-core';
+
+export const TypescriptTypeRegistry = {
+  register(typeMetadata: any): void {
+    TypeMetadata.loadFromJson(typeMetadata);
+  },
+};

--- a/golem-ts-sdk/tests/testAgents.ts
+++ b/golem-ts-sdk/tests/testAgents.ts
@@ -17,8 +17,6 @@
 import { agent, BaseAgent } from '../src';
 import * as Types from './testTypes';
 
-console.log('Loading Agents');
-
 @agent()
 class WeatherAgent extends BaseAgent {
   constructor(readonly testInterfaceType: Types.TestInterfaceType) {

--- a/golem-ts-sdk/tests/testSetup.ts
+++ b/golem-ts-sdk/tests/testSetup.ts
@@ -1,6 +1,6 @@
 import { TypeMetadata } from '@golemcloud/golem-ts-types-core';
 import { Metadata } from '../.metadata/generated-types';
-import { TypescriptTypeRegistry } from '../src/typescriptTypeRegistry';
+import { TypescriptTypeRegistry } from '../src';
 
 // This setup is ran before every test suite (vitest worker)
 // and represents the entry point of any code-first user code

--- a/golem-ts-sdk/tests/testSetup.ts
+++ b/golem-ts-sdk/tests/testSetup.ts
@@ -1,10 +1,11 @@
 import { TypeMetadata } from '@golemcloud/golem-ts-types-core';
 import { Metadata } from '../.metadata/generated-types';
+import { TypescriptTypeRegistry } from '../src/typescriptTypeRegistry';
 
 // This setup is ran before every test suite (vitest worker)
 // and represents the entry point of any code-first user code
 
-TypeMetadata.loadFromJson(Metadata);
+TypescriptTypeRegistry.register(Metadata);
 
 export default (async () => {
   const result = await import('./testAgents');


### PR DESCRIPTION
* Users code should have only `golem-ts-sdk` in their dependencies (and that is external)
* `golem-ts-types-core` dependencies  shouldn't exist anywhere in their code
* `golem-ts-typegen` exist only as a dev dependency 