### PR TITLE
Add actual initiator and invoke tests in SDK

### DIFF
--- a/golem-ts-sdk/README.md
+++ b/golem-ts-sdk/README.md
@@ -8,36 +8,24 @@ import {
     description,
 } from '@golemcloud/golem-ts-sdk';
 
-import * as Either from '@golemcloud/golem-ts-sdk';
-
-type Question = {
-    text: string
+type Input = {
+    username: string,
+    location: Location
 }
 
-type Location = { lat: number, long: number };
-type LocationName = string;
+type GeoLocation = { lat: number, long: number };
 
-type Loc = Location | LocationName;
+type Name = string;
+
+type Place = Name | GeoLocation;
 
 @agent()
 class AssistantAgent extends BaseAgent {
-    
-    @prompt("Ask your question")
+    @prompt("Public weather forecast")
     @description("This method allows the agent to answer your question")
-    async ask(question: Question): Promise<string> {
-        
-        const location: Loc = { lat: 12.34, long: 56.78 };
-
-        const remoteWeatherClient = WeatherAgent.createRemote("afsal");
-        const remoteWeather = await remoteWeatherClient.getWeather(location);
-
-        const localWeatherClient = WeatherAgent.createLocal("afsal");
-        const localWeather = await localWeatherClient.getWeather(location);
-
-        return (
-            `Remote agent result: ${remoteWeather}\n` +
-            `Local agent result: ${localWeather}\n`
-        );
+    async ask(input: Input): Promise<string> {
+        const remoteWeatherClient = WeatherAgent.createRemote(input.username);
+        return await remoteWeatherClient.getWeather(input.location);
     }
 }
 
@@ -51,13 +39,11 @@ class WeatherAgent extends BaseAgent {
     }
 
     @prompt("Get weather")
-    @description("Weather forecast weather for you")
-    async getWeather(location: Location): Promise<Either.Either<string, string>> {
+    @description("Internal weather forecasting service. Only accessible if authorized.")
+    async getWeather(location: Place): Promise<String> {
         return Promise.resolve(
-            Either.ok(
-                `Hi ${this.userName} ! Weather in ${location} is sunny. ` +
-                `Reported by weather-agent ${this.getId()}. `
-            )
+            `Hi ${this.userName} ! Weather in ${location} is sunny. ` + 
+            `Reported by weather-agent ${this.getId()}. `
         );
     }
 }

--- a/golem-ts-sdk/src/decorators.ts
+++ b/golem-ts-sdk/src/decorators.ts
@@ -323,7 +323,7 @@ export function agent() {
 
               return {
                 tag: 'ok',
-                val: getDataValueFromWitValueReturned(returnValue.right),
+                val: getDataValueFromWitValue(returnValue.right),
               };
             },
           };
@@ -361,7 +361,9 @@ export function description(desc: string) {
 }
 
 // FIXME: in the next version, handle all dataValues
-function getWitValueFromDataValue(dataValue: DataValue): WitValue.WitValue[] {
+export function getWitValueFromDataValue(
+  dataValue: DataValue,
+): WitValue.WitValue[] {
   if (dataValue.tag === 'tuple') {
     return dataValue.val.map((elem) => {
       if (elem.tag === 'component-model') {
@@ -377,7 +379,7 @@ function getWitValueFromDataValue(dataValue: DataValue): WitValue.WitValue[] {
 
 // Why is return value a tuple with a single element?
 // why should it have a name?
-function getDataValueFromWitValueReturned(
+export function getDataValueFromWitValue(
   witValues: WitValue.WitValue,
 ): DataValue {
   return {

--- a/golem-ts-sdk/tests/agentsInit.ts
+++ b/golem-ts-sdk/tests/agentsInit.ts
@@ -1,0 +1,13 @@
+import { TypeMetadata } from '@golemcloud/golem-ts-types-core';
+import { Metadata } from '../.metadata/generated-types';
+import { TypescriptTypeRegistry } from '../src';
+
+// This setup is ran before every test suite (vitest worker)
+// and represents the entry point of any code-first user code
+TypescriptTypeRegistry.register(Metadata);
+
+await import('./testAgents');
+
+console.log(
+  `✅ Test-setup: Successfully loaded type metadata and imported agents (decorators). Total classes tracked: ${TypeMetadata.getAll().size}`,
+);

--- a/golem-ts-sdk/tests/decorator.test.ts
+++ b/golem-ts-sdk/tests/decorator.test.ts
@@ -1,11 +1,23 @@
 import { AgentTypeRegistry } from '../src/internal/registry/agentTypeRegistry';
 import { AgentClassName } from '../src';
-import { AgentMethodMetadataRegistry } from '../src/internal/registry/agentMethodMetadataRegistry';
 import * as Option from 'effect/Option';
+import * as Either from 'effect/Either';
 import { expect } from 'vitest';
+import { AgentInitiatorRegistry } from '../src/internal/registry/agentInitiatorRegistry';
+import { AgentTypeName } from '../src/newTypes/agentTypeName';
+import { TypeMetadata } from '@golemcloud/golem-ts-types-core';
+import * as WitValue from '../src/internal/mapping/values/WitValue';
+import { getDataValueFromWitValue } from '../src/decorators';
+import * as GolemApiHostModule from 'golem:api/host@1.1.7';
 
 const AssistantAgentClassName = new AgentClassName('AssistantAgent');
 const WeatherAgentClassName = new AgentClassName('WeatherAgent');
+const WeatherAgentName = AgentTypeName.fromAgentClassName(
+  WeatherAgentClassName,
+);
+const AssistantAgentName = AgentTypeName.fromAgentClassName(
+  AssistantAgentClassName,
+);
 
 // See testAgents.ts for the agent classes with decorators, which is imported before every test suite via testSetup.ts
 it('Agent decorator should register the agent class and its methods into AgentTypeRegistry', () => {
@@ -24,3 +36,52 @@ it('Agent decorator should register the agent class and its methods into AgentTy
   expect(weatherAgent.methods.length).toEqual(1);
   expect(weatherAgent.constructor.inputSchema.val.length).toEqual(1);
 });
+
+it('WeatherAgent should have method with correct name and description', () => {
+  overrideSelfMetadataImpl();
+
+  const typeRegistry = TypeMetadata.get(WeatherAgentClassName.value);
+
+  if (!typeRegistry) {
+    throw new Error('WeatherAgent type metadata not found');
+  }
+
+  const constructorInfo = typeRegistry.constructorArgs[0].type;
+
+  const constructorArg = 'foo';
+
+  const witValue = Either.getOrThrowWith(
+    WitValue.fromTsValue(constructorArg, constructorInfo),
+    (error) =>
+      new Error(`Failed to convert constructor arg to WitValue. ${error}`),
+  );
+
+  const constructorParams = getDataValueFromWitValue(witValue);
+
+  const agentInitiator = Option.getOrThrowWith(
+    AgentInitiatorRegistry.lookup(WeatherAgentName),
+    () => new Error('WeatherAgent not found in AgentInitiatorRegistry'),
+  );
+
+  const result = agentInitiator.initiate(
+    WeatherAgentName.value,
+    constructorParams,
+  );
+
+  expect(1).toEqual(1);
+});
+
+function overrideSelfMetadataImpl() {
+  vi.spyOn(GolemApiHostModule, 'getSelfMetadata').mockImplementation(() => ({
+    workerId: {
+      componentId: { uuid: { highBits: 42n, lowBits: 99n } },
+      workerName: 'weather-agent',
+    },
+    args: [],
+    env: [],
+    wasiConfigVars: [],
+    status: 'running',
+    componentVersion: 0n,
+    retryCount: 0n,
+  }));
+}

--- a/golem-ts-sdk/tests/testAgents.ts
+++ b/golem-ts-sdk/tests/testAgents.ts
@@ -12,31 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Test Setup configured in vitest.config.ts
-
 import { agent, BaseAgent } from '../src';
 import * as Types from './testTypes';
 
 @agent()
 class WeatherAgent extends BaseAgent {
-  constructor(readonly testInterfaceType: Types.TestInterfaceType) {
+  constructor(readonly input: string) {
     super();
-    this.testInterfaceType = testInterfaceType;
+    this.input = input;
   }
 
-  async getWeather(
-    complexType: Types.ObjectComplexType,
-    unionType: Types.UnionType,
-    unionComplexType: Types.UnionComplexType,
-    numberType: Types.NumberType,
-    stringType: Types.StringType,
-    booleanType: Types.BooleanType,
-    mapType: Types.MapType,
-    tupleComplexType: Types.TupleComplexType,
-    tupleType: Types.TupleType,
-    listComplexType: Types.ListComplexType,
-    objectType: Types.ObjectType,
-  ): Types.PromiseType {
+  async getWeather(value: string): Types.PromiseType {
     return Promise.resolve(`Weather for ${location} is sunny!`);
   }
 }

--- a/golem-ts-sdk/tests/testSetup.ts
+++ b/golem-ts-sdk/tests/testSetup.ts
@@ -1,18 +1,24 @@
-import { TypeMetadata } from '@golemcloud/golem-ts-types-core';
-import { Metadata } from '../.metadata/generated-types';
-import { TypescriptTypeRegistry } from '../src';
+import { vi } from 'vitest';
 
-// This setup is ran before every test suite (vitest worker)
-// and represents the entry point of any code-first user code
+// Global mocks which will be used within decorators,
+// These host functionalities shouldn't run when decorators run.
+// For example, getSelfMetadata is used in some decorators, however,
+// it executes only when `initiate` is called.
+// Also, these mocks are just place-holders. We can override the behavior
+// per tests using functionalities overrides module
+vi.mock('golem:api/host@1.1.7', () => ({
+  getSelfMetadata: () => ({
+    workerId: {
+      componentId: { uuid: { highBits: 0n, lowBits: 0n } },
+      workerName: 'change-this-by-overriding',
+    },
+    args: [],
+    env: [],
+    wasiConfigVars: [],
+    status: 'running',
+    componentVersion: 0n,
+    retryCount: 0n,
+  }),
+}));
 
-TypescriptTypeRegistry.register(Metadata);
-
-export default (async () => {
-  const result = await import('./testAgents');
-
-  console.log(
-    `✅ Test-setup: Successfully loaded type metadata and imported agents (decorators). Total classes tracked: ${TypeMetadata.getAll().size}`,
-  );
-
-  return result;
-})();
+await import('./agentsInit');

--- a/golem-ts-sdk/tests/type.mapping.test.ts
+++ b/golem-ts-sdk/tests/type.mapping.test.ts
@@ -29,6 +29,7 @@ import * as AnalysedType from '../src/internal/mapping/types/AnalysedType';
 import * as Either from 'effect/Either';
 import * as Option from 'effect/Option';
 import { NameTypePair } from '../src/internal/mapping/types/AnalysedType';
+import { WorkerMetadata } from 'golem:api/host@1.1.7';
 
 // Interface type indirectly tests primitive types, union, list etc
 describe('TypeScript Interface to AnalysedType', () => {

--- a/golem-ts-sdk/vitest.config.ts
+++ b/golem-ts-sdk/vitest.config.ts
@@ -9,9 +9,6 @@ export default defineConfig({
     },
     resolve: {
         alias: {
-            // FIXME: The test runtime module for golem host and rpc resolution is pointing back to declaration files.
-            // This is with the assumption that SDK unit tests will never end up using the actual golem host implementation modules
-            // That should be part of integration tests.
             'golem:rpc/types@0.2.2': path.resolve(__dirname, 'types/golem_rpc_0_2_2_types.d.ts'),
             'golem:api/host@1.1.7': path.resolve(__dirname, 'types/golem_api_1_1_7_host.d.ts'),
             'golem:agent/common': path.resolve(__dirname, 'types/golem_agent_common.d.ts'),


### PR DESCRIPTION
We already run decorators within unit tests, and make sure they are not buggy.
But we never call those functionalities registered by decorator in unit tests. Example `initiate` agents.
This PR covers this part, and in fact the actual invoke will also be covered. 
