### PR TITLE
Distinguish between class and object

### DIFF
--- a/golem-ts-types-core/package.json
+++ b/golem-ts-types-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@golemcloud/golem-ts-types-core",
   "type": "module",
-  "version": "0.0.1-dev.5",
+  "version": "0.0.1-dev.6",
   "publishConfig": {
     "access": "public",
     "tag": "test"

--- a/golem-ts-types-core/src/type-json.ts
+++ b/golem-ts-types-core/src/type-json.ts
@@ -40,7 +40,6 @@ export type LiteTypeJSON =
         type: LiteTypeJSON;
         optional?: boolean;
       }>;
-
     }
   | {
       kind: 'interface';

--- a/golem-ts-types-core/src/type-json.ts
+++ b/golem-ts-types-core/src/type-json.ts
@@ -33,6 +33,16 @@ export type LiteTypeJSON =
       }>;
     }
   | {
+      kind: 'class';
+      name: string;
+      properties: Array<{
+        name: string;
+        type: LiteTypeJSON;
+        optional?: boolean;
+      }>;
+
+    }
+  | {
       kind: 'interface';
       name?: string;
       properties: Array<{

--- a/golem-ts-types-core/src/type-lite.ts
+++ b/golem-ts-types-core/src/type-lite.ts
@@ -25,6 +25,7 @@ type Kind =
   | 'tuple'
   | 'union'
   | 'object'
+  | 'class'
   | 'interface'
   | 'promise'
   | 'map'
@@ -101,6 +102,10 @@ export class Type {
 
   isPromise(): boolean {
     return this.kind === 'promise';
+  }
+
+  isClass(): boolean {
+    return this.kind === 'class';
   }
 
   isMap(): boolean {

--- a/golem-ts-types-core/src/type-to-json.ts
+++ b/golem-ts-types-core/src/type-to-json.ts
@@ -91,6 +91,25 @@ export function buildJSONFromType(type: Type): LiteTypeJSON {
     };
   }
 
+  if (type.isClass()) {
+    const props = type.getProperties().map((sym) => {
+      const decl = sym.getDeclarations()[0];
+      const optional = decl.hasQuestionToken?.() ?? false;
+      const propType = sym.getTypeAtLocation(decl);
+      return {
+        name: sym.getName(),
+        type: buildJSONFromType(propType),
+        optional: optional || undefined,
+      };
+    });
+
+    return {
+      kind: type.isObject() ? 'object' : 'interface',
+      name: type.getName(),
+      properties: props,
+    };
+  }
+
   if (type.isMap()) {
     const keyAndValue = type.getTypeArguments();
 
@@ -122,6 +141,6 @@ export function buildJSONFromType(type: Type): LiteTypeJSON {
   }
 
   throw new Error(
-    `Failed to convert Type to JSON type. Unsupported type: ${type.getName() ?? 'unknown'}`,
+    `Failed to convert Type (kind: ${type.getKind()}) to JSON type. Unsupported type: ${type.getName() ?? 'unknown'}`,
   );
 }


### PR DESCRIPTION
@mschuwalow  found that class names were successfully type extracted, making it difficult for the moonbit generations to handle. 

This is just first part of the fix.

There will be follow up PRs that handles the following
* type-gen will generate metadata that specifically tags it as a class instead of an object
* in ts-sdk, if the metadata is pointing to a class, we will choose to fail rather than processing it
* in ts-sdk, if the number of parameters in object or interface is empty, then we choose to fail
