### PR TITLE
update typegen to distinguish class and object

### DIFF
--- a/golem-ts-typegen/package-lock.json
+++ b/golem-ts-typegen/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1-dev.6",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@golemcloud/golem-ts-types-core": "^0.0.1-dev.5",
+        "@golemcloud/golem-ts-types-core": "^0.0.1-dev.6",
         "chalk": "^5.3.0",
         "commander": "^14.0.0",
         "log-symbols": "^7.0.1",
@@ -693,9 +693,9 @@
       }
     },
     "node_modules/@golemcloud/golem-ts-types-core": {
-      "version": "0.0.1-dev.5",
-      "resolved": "https://registry.npmjs.org/@golemcloud/golem-ts-types-core/-/golem-ts-types-core-0.0.1-dev.5.tgz",
-      "integrity": "sha512-g2ABaX5Ptj7Xcgw3jKIJ1ivXhMVY5hJnFbctDUPs6YW2wb32M1xKHgA2Sst146KS3kjrmMolJhYRlTh/ZkTBHw==",
+      "version": "0.0.1-dev.7",
+      "resolved": "https://registry.npmjs.org/@golemcloud/golem-ts-types-core/-/golem-ts-types-core-0.0.1-dev.7.tgz",
+      "integrity": "sha512-EpAx9tnXgJch3jbU1g14AoRKYpga7ZT13f8AXVYel53KTUelIwr/rEI89cuQlFYuKT6acJHzAh5Si6f2q1ek0A==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@humanfs/core": {

--- a/golem-ts-typegen/package.json
+++ b/golem-ts-typegen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@golemcloud/golem-ts-typegen",
   "type": "module",
-  "version": "0.0.1-dev.6",
+  "version": "0.0.1-dev.7",
   "publishConfig": {
     "access": "public",
     "tag": "test"
@@ -71,7 +71,7 @@
   },
   "private": false,
   "dependencies": {
-    "@golemcloud/golem-ts-types-core": "^0.0.1-dev.5",
+    "@golemcloud/golem-ts-types-core": "^0.0.1-dev.6",
     "commander": "^14.0.0",
     "log-symbols": "^7.0.1",
     "ts-morph": "^26.0.0",

--- a/golem-ts-typegen/src/index.ts
+++ b/golem-ts-typegen/src/index.ts
@@ -186,6 +186,40 @@ export function getFromTsMorph(tsMorphType: TsMorphType): Type {
     });
   }
 
+  if (type.isClass()) {
+    const result: Symbol[] = type.getProperties().map((prop) => {
+      const type = prop.getTypeAtLocation(prop.getValueDeclarationOrThrow());
+      const nodes = prop.getDeclarations();
+      const node = nodes[0];
+      const tsType = getFromTsMorph(type);
+      const propName = prop.getName();
+
+      if (
+        (TsMorphNode.isPropertySignature(node) ||
+          TsMorphNode.isPropertyDeclaration(node)) &&
+        node.hasQuestionToken()
+      ) {
+        return new Symbol({
+          name: propName,
+          declarations: [new Node("PropertyDeclaration", true)],
+          typeAtLocation: tsType,
+        });
+      } else {
+        return new Symbol({
+          name: propName,
+          declarations: [new Node("PropertyDeclaration", false)],
+          typeAtLocation: tsType,
+        });
+      }
+    });
+
+    return new Type({
+      kind: "class",
+      name,
+      properties: result,
+    });
+  }
+
   if (type.isInterface()) {
     const result: Symbol[] = type.getProperties().map((prop) => {
       const type = prop.getTypeAtLocation(prop.getValueDeclarationOrThrow());

--- a/golem-ts-typegen/tests/metadata.test.ts
+++ b/golem-ts-typegen/tests/metadata.test.ts
@@ -25,6 +25,7 @@ import {
   getUnionType,
   getComplexObjectType,
   getInterfaceType,
+  getClassType,
 } from "./util.js";
 
 describe("golem-ts-typegen can work correctly read types from .metadata directory", () => {
@@ -77,5 +78,10 @@ describe("golem-ts-typegen can work correctly read types from .metadata director
   it("track interface type", () => {
     const tupleType = getInterfaceType();
     expect(tupleType.isInterface()).toEqual(true);
+  });
+
+  it("track class type", () => {
+    const classType = getClassType();
+    expect(classType.isClass()).toEqual(true);
   });
 });

--- a/golem-ts-typegen/tests/testData.ts
+++ b/golem-ts-typegen/tests/testData.ts
@@ -48,6 +48,16 @@ export type ObjectComplexType = {
   k: SimpleInterfaceType;
 };
 
+export class FooBar {
+  constructor(
+    public name: string,
+    public value: number,
+  ) {
+    this.name = name;
+    this.value = value;
+  }
+}
+
 export interface TestInterfaceType {
   numberProp: number;
   stringProp: string;
@@ -98,6 +108,7 @@ class MyAgent {
     objectType: ObjectType,
     unionWithLiteral: "foo" | "bar" | 1 | true | false,
     objectWithLiteral: { tag: "inline"; val: string },
+    classType: FooBar,
   ): PromiseType {
     return Promise.resolve(`Weather for ${location} is sunny!`);
   }

--- a/golem-ts-typegen/tests/util.ts
+++ b/golem-ts-typegen/tests/util.ts
@@ -98,6 +98,10 @@ export function getPromiseType(): Type {
   return fetchType("Promise");
 }
 
+export function getClassType(): Type {
+  return fetchType("FooBar");
+}
+
 // Fetch a type by its name from the loaded metadata (loaded by setup module)
 function fetchType(typeNameInTestData: string): Type {
   const classMetadata = Array.from(getAll()).map(([_, v]) => v);


### PR DESCRIPTION
Given core types talk about `kind:class`, now typegen can be updated to piggyback on it.
Later golem-ts-sdk can do whatever it wants with class types