### PR TITLE
Check support for void, undefined and null and extend tests

### DIFF
--- a/golem-ts-agentic/package.json
+++ b/golem-ts-agentic/package.json
@@ -3,7 +3,6 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "preinstall": "pnpm --filter @golemcloud/golem-ts-types-core run build",
         "build": "pnpm --filter @golemcloud/golem-ts-types-core run build && pnpm --filter @golemcloud/golem-ts-typegen run build && pnpm --filter @golemcloud/golem-ts-sdk run build",
         "lint": "pnpm -r run lint",
         "test": "pnpm -r run test",

--- a/golem-ts-agentic/packages/golem-ts-sdk/package.json
+++ b/golem-ts-agentic/packages/golem-ts-sdk/package.json
@@ -37,11 +37,11 @@
     "format:check": "prettier --check \"src/**/*\" \"tests/**/*\"",
     "generate-dts": "wasm-rquickjs generate-dts --wit ../../../wit --output types",
     "clean-test-data": "rm -rf .metadata",
-    "generate-test-types-metadata": "pnpm exec golem-typegen ./tsconfig.json --files tests/**/*.ts",
+    "generate-test-types-metadata": "node ../golem-ts-typegen/dist/bin/golem-typegen ./tsconfig.json --files tests/**/*.ts",
     "prebuild": "npm run clean-test-data && pnpm run generate-dts && pnpm run generate-test-types-metadata",
     "build": "npm run prebuild && tsc --noEmit && rollup -c",
     "clean": "rm -rf .metadata dist node_modules package-lock.json && printf '\\nRun `npm install` before building again.\\n\\n'",
-    "test": "pnpm run clean-test-data && npm run generate-test-types-metadata && tsc --noEmit && vitest run",
+    "test": "pnpm run clean-test-data && pnpm run build && pnpm run generate-test-types-metadata && tsc --noEmit && vitest run",
     "dev": "rollup -c -w"
   },
   "keywords": [],
@@ -53,7 +53,6 @@
   "description": "",
   "devDependencies": {
     "@eslint/js": "^9.33.0",
-    "@golemcloud/golem-ts-typegen": "workspace:*",
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@types/node": "^24.3.0",

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/types/AnalysedType.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/types/AnalysedType.ts
@@ -229,6 +229,9 @@ export function fromTsTypeInternal(type: TsType): Either.Either<AnalysedType, st
     case "undefined":
       return Either.right(tuple([]))
 
+    case "void":
+      return Either.right(tuple([]))
+
     case "tuple":
       const tupleElems = Either.all(type.elements.map(el => fromTsTypeInternal(el)));
       return Either.map(tupleElems, (items) => tuple(items));

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/types/AnalysedType.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/types/AnalysedType.ts
@@ -405,7 +405,7 @@ export function fromTsTypeInternal(type: TsType): Either.Either<AnalysedType, st
       }
 
 
-      return Either.left(`Type "${customTypeName}" is not supported`)
+      return Either.left(`Unsupported type \`${customTypeName}\``)
 
     case 'array':
       const name = type.name;

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/values/Value.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/values/Value.ts
@@ -348,6 +348,9 @@ export function fromTsValue(
     case 'undefined':
       return Either.right({ kind: 'tuple', value: [] });
 
+    case 'void':
+      return Either.right({ kind: 'tuple', value: [] });
+
     case 'array':
       switch (type.name) {
         case 'Int8Array':
@@ -719,6 +722,9 @@ function matchesType(value: any, type: Type.Type): boolean {
 
     case 'undefined':
       return value === undefined;
+
+    case 'void':
+      return value === undefined || value === null;
 
     case 'array':
       const elemType = type.element;

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/schema.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/schema.ts
@@ -126,7 +126,7 @@ export function buildInputSchema(
           return [parameterInfo[0], result] as [string, ElementSchema];
         },
         (err) =>
-          `${err}, found in method \`${methodName}\`, parameter \`${parameterInfo[0]}\`. Please replace this parameter type with a simpler, supported type"`,
+          `${err}, found in method \`${methodName}\`, parameter \`${parameterInfo[0]}\`. Please replace this parameter type with a simpler, supported type."`,
       ),
     ),
   );

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
@@ -61,6 +61,9 @@ class AssistantAgent extends BaseAgent {
     listComplexType: Types.ListComplexType,
     objectType: Types.ObjectType,
     UnionOfLiterals: UnionOfLiterals,
+    voidType: void,
+    nullType: null,
+    undefinedType: undefined,
   ): Types.PromiseType {
     return Promise.resolve(`Weather for ${location} is sunny!`);
   }

--- a/golem-ts-agentic/packages/golem-ts-typegen/package.json
+++ b/golem-ts-agentic/packages/golem-ts-typegen/package.json
@@ -31,7 +31,6 @@
     }
   },
   "scripts": {
-    "prepare": "pnpm run build",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write \"src/**/*\" \"tests/**/*\"",

--- a/golem-ts-agentic/packages/golem-ts-typegen/src/index.ts
+++ b/golem-ts-agentic/packages/golem-ts-typegen/src/index.ts
@@ -163,6 +163,10 @@ export function getFromTsMorph(tsMorphType: TsMorphType): Type.Type {
     };
   }
 
+  if (type.isVoid()) {
+    return { kind: "void", name: "void" };
+  }
+
   if (type.isBoolean() || rawName === "true" || rawName === "false") {
     return { kind: "boolean", name: "boolean" };
   }

--- a/golem-ts-agentic/packages/golem-ts-typegen/tests/testData.ts
+++ b/golem-ts-agentic/packages/golem-ts-typegen/tests/testData.ts
@@ -113,6 +113,9 @@ class MyAgent {
     classType: FooBar,
     recordType: Record<string, number>,
     recordTypeAliased: RecordType,
+    voidType: void,
+    undefinedType: undefined,
+    nullType: null,
   ): PromiseType {
     return Promise.resolve(`Weather for ${location} is sunny!`);
   }

--- a/golem-ts-agentic/packages/golem-ts-types-core/src/json-to-type.ts
+++ b/golem-ts-agentic/packages/golem-ts-types-core/src/json-to-type.ts
@@ -21,18 +21,27 @@ export function buildTypeFromJSON(json: LiteTypeJSON): Type {
   switch (json.kind) {
     case 'others':
       return { kind: 'others', name: json.name };
+
     case 'boolean':
       return { kind: 'boolean', name: json.name };
+
     case 'number':
       return { kind: 'number', name: json.name };
+
     case 'string':
       return { kind: 'string', name: json.name };
+
     case 'bigint':
       return { kind: 'bigint', name: json.name };
+
     case 'null':
       return { kind: 'null', name: json.name };
+
     case 'undefined':
       return { kind: 'undefined', name: json.name };
+
+    case 'void':
+      return { kind: 'void', name: json.name };
 
     case 'array': {
       const elem = buildTypeFromJSON(json.element);

--- a/golem-ts-agentic/packages/golem-ts-types-core/src/type-json.ts
+++ b/golem-ts-agentic/packages/golem-ts-types-core/src/type-json.ts
@@ -19,6 +19,7 @@ export type LiteTypeJSON =
   | { kind: 'bigint'; name?: string }
   | { kind: 'null'; name?: string }
   | { kind: 'undefined'; name?: string }
+  | { kind: 'void'; name?: string }
   | { kind: 'array'; name?: string; element: LiteTypeJSON }
   | { kind: 'tuple'; name?: string; elements: LiteTypeJSON[] }
   | { kind: 'union'; name?: string; types: LiteTypeJSON[] }

--- a/golem-ts-agentic/packages/golem-ts-types-core/src/type-lite.ts
+++ b/golem-ts-agentic/packages/golem-ts-types-core/src/type-lite.ts
@@ -31,6 +31,7 @@ export type Type =
   | { kind: 'map'; name?: string; key: Type; value: Type }
   | { kind: 'literal'; name?: string }
   | { kind: 'alias'; name?: string; aliasSymbol: Symbol }
+  | { kind: 'void'; name?: string }
   | { kind: 'others'; name?: string };
 
 export function getName(t: Type): string | undefined {
@@ -66,28 +67,8 @@ export function getAliasSymbol(t: Type): Symbol | undefined {
   return t.kind === 'alias' ? t.aliasSymbol : undefined;
 }
 
-// Get human-readable type name (exhaustive)
 export function getTypeName(t: Type): string {
-  switch (t.kind) {
-    case 'boolean':
-    case 'number':
-    case 'string':
-    case 'bigint':
-    case 'null':
-    case 'undefined':
-    case 'array':
-    case 'tuple':
-    case 'union':
-    case 'object':
-    case 'interface':
-    case 'promise':
-    case 'map':
-    case 'literal':
-    case 'class':
-    case 'alias':
-    case 'others':
-      return t.name ?? t.kind;
-  }
+  return t.name ? t.name : t.kind;
 }
 
 export function unwrapAlias(t: Type): Type {

--- a/golem-ts-agentic/packages/golem-ts-types-core/src/type-to-json.ts
+++ b/golem-ts-agentic/packages/golem-ts-types-core/src/type-to-json.ts
@@ -32,6 +32,9 @@ export function buildJSONFromType(type: Type.Type): LiteTypeJSON {
     case 'undefined':
       return { kind: 'undefined', name: type.name };
 
+    case 'void':
+      return { kind: 'void', name: type.name };
+
     case 'array':
       const elem = Type.getArrayElementType(type);
 

--- a/golem-ts-agentic/pnpm-lock.yaml
+++ b/golem-ts-agentic/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       '@eslint/js':
         specifier: ^9.33.0
         version: 9.35.0
-      '@golemcloud/golem-ts-typegen':
-        specifier: workspace:*
-        version: link:../golem-ts-typegen
       '@rollup/plugin-commonjs':
         specifier: ^28.0.6
         version: 28.0.6(rollup@4.50.0)


### PR DESCRIPTION
Also if the types are not supported, then here is an example

> Schema generation failed for agent class AssistantAgent. Unsupported type `__@iterator@80`, found in method `getWeather`, parameter `unsupportedType`. Please replace this parameter type with a simpler, supported type