### PR TITLE
Control metadata generation

### DIFF
--- a/golem-ts-agentic/packages/golem-ts-sdk/package.json
+++ b/golem-ts-agentic/packages/golem-ts-sdk/package.json
@@ -37,7 +37,7 @@
     "format:check": "prettier --check \"src/**/*\" \"tests/**/*\"",
     "generate-dts": "wasm-rquickjs generate-dts --wit ../../../wit --output types",
     "clean-test-data": "rm -rf .metadata",
-    "generate-sample-agents-types": "node ../golem-ts-typegen/dist/bin/golem-typegen ./tsconfig.json --files tests/**/*.ts",
+    "generate-sample-agents-types": "node ../golem-ts-typegen/dist/bin/golem-typegen ./tsconfig.json --files tests/**/*.ts --include-class-decorators agent",
     "prebuild": "npm run clean-test-data && pnpm run generate-dts && pnpm run generate-sample-agents-types",
     "build": "npm run prebuild && tsc --noEmit && rollup -c",
     "clean": "rm -rf .metadata dist node_modules package-lock.json && printf '\\nRun `npm install` before building again.\\n\\n'",

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
@@ -168,3 +168,13 @@ class AssistantAgent extends BaseAgent {
     console.log('Hello World');
   };
 }
+
+// If this class is decorated with agent, it will fail
+// This is kept here to ensure that any internal user class is not part of metadata generation.
+// See package.json for metadata generation command.
+class InternalClass {
+  async fun1(input: string): Promise<Iterator<string>> {
+    const array = ['a', 'b', 'c'];
+    return array[Symbol.iterator]();
+  }
+}

--- a/golem-ts-agentic/packages/golem-ts-typegen/tests/setup.ts
+++ b/golem-ts-agentic/packages/golem-ts-typegen/tests/setup.ts
@@ -19,7 +19,7 @@
  * Every testing is performed on top of the metadata directory.
  */
 import { Project } from "ts-morph";
-import { generateMetadata } from "../src/index";
+import { generateClassMetadata } from "../src/index";
 
 const project = new Project({
   tsConfigFilePath: "tsconfig.json",
@@ -27,4 +27,8 @@ const project = new Project({
 
 const sourceFiles = project.getSourceFiles("tests/testData.ts");
 
-generateMetadata(sourceFiles);
+generateClassMetadata({
+  sourceFiles: sourceFiles,
+  includeOnlyPublicScope: true,
+  classDecorators: [],
+});


### PR DESCRIPTION
PR: Only classes that are decorated with `agent` take part in metadata generation

* Although we didn't bump into issues during testing, I would say it's a risk to generate metadata for any classes in the code, even if typegen hardly fails with recent improvements.
* And if it fails for some reason, it should correspond to only agent classes
* Also configurable "scope". By default only public scoped properties take part in generation