### PR TITLE
Fix value conversions for number

### DIFF
--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/values/Value.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/values/Value.ts
@@ -763,7 +763,7 @@ function fromTsValueInternal(
           });
         } else if (typeof tsValue === 'number') {
           return Either.right({
-            kind: 's32',
+            kind: 'f64',
             value: tsValue,
           });
         } else if (typeof tsValue === 'bigint') {
@@ -948,7 +948,7 @@ function handleObject(
           });
         } else if (propType.kind === 'number' && tsValue === 0) {
           values.push({
-            kind: 's32',
+            kind: 'f64',
             value: 0,
           });
         } else if (propType.kind === 'boolean' && tsValue === false) {
@@ -1624,6 +1624,7 @@ export function toTsValue(value: Value, type: Type.Type): any {
       if (
         value.kind === 'bool' ||
         value.kind === 'string' ||
+        value.kind === 'f64' ||
         value.kind === 's32'
       ) {
         return value.value;

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/values/Value.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/values/Value.ts
@@ -551,7 +551,7 @@ function fromTsValueInternal(
     case 'number':
       if (typeof tsValue === 'number') {
         return Either.right({
-          kind: 's32',
+          kind: 'f64',
           value: tsValue,
         });
       } else {

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
@@ -48,7 +48,7 @@ test('SimpleAgent can be successfully initiated and all of its methods can be in
   fc.assert(
     fc.property(
       fc.string(),
-      fc.oneof(fc.oneof(fc.integer(), fc.float()), fc.float()),
+      fc.oneof(fc.oneof(fc.integer(), fc.float())),
       stringOrNumberOrNull,
       objectWithUnionWithUndefined1Arb,
       objectWithUnionWithUndefined2Arb,


### PR DESCRIPTION
Internally certain mapping still used s32. The round trip tests were happy with this. 