### PR TITLE
Fix bugs and add tests to ensure overridden functions or arrows are not included as agent methods

### DIFF
--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/decorator.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/decorator.test.ts
@@ -432,6 +432,26 @@ describe('Agent decorator should register the agent class and its methods into A
     expect(simpleAgent.methods.length).toEqual(13);
     expect(simpleAgent.constructor.inputSchema.val.length).toEqual(1);
   });
+
+  it('should not capture overridden functions in base agents as agent methods', () => {
+    const simpleAgent = Option.getOrThrowWith(
+      AgentTypeRegistry.lookup(SimpleAgentClassName),
+      () => new Error('WeatherAgent not found in AgentTypeRegistry'),
+    );
+
+    const forbidden = [
+      'get-id',
+      'get-agent-type',
+      'load-snapshot',
+      'save-snapshot',
+    ];
+
+    [complexAgent, simpleAgent].forEach((agent) => {
+      forbidden.forEach((name) => {
+        expect(agent.methods.find((m) => m.name === name)).toBeUndefined();
+      });
+    });
+  });
 });
 
 function getWitType(dataSchema: DataSchema, parameterName: string) {

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/decorator.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/decorator.test.ts
@@ -24,7 +24,7 @@ import * as util from 'node:util';
 describe('Agent decorator should register the agent class and its methods into AgentTypeRegistry', () => {
   const complexAgent: AgentType = Option.getOrThrowWith(
     AgentTypeRegistry.lookup(ComplexAgentClassName),
-    () => new Error('AssistantAgent not found in AgentTypeRegistry'),
+    () => new Error('ComplexAgent not found in AgentTypeRegistry'),
   );
 
   const complexAgentConstructor = complexAgent.constructor;
@@ -424,7 +424,7 @@ describe('Agent decorator should register the agent class and its methods into A
   it('captures all methods and constructor with correct number of parameters', () => {
     const simpleAgent = Option.getOrThrowWith(
       AgentTypeRegistry.lookup(SimpleAgentClassName),
-      () => new Error('WeatherAgent not found in AgentTypeRegistry'),
+      () => new Error('SimpleAgent not found in AgentTypeRegistry'),
     );
 
     expect(complexAgent.methods.length).toEqual(22);
@@ -436,7 +436,7 @@ describe('Agent decorator should register the agent class and its methods into A
   it('should not capture overridden functions in base agents as agent methods', () => {
     const simpleAgent = Option.getOrThrowWith(
       AgentTypeRegistry.lookup(SimpleAgentClassName),
-      () => new Error('WeatherAgent not found in AgentTypeRegistry'),
+      () => new Error('SimpleAgent not found in AgentTypeRegistry'),
     );
 
     const forbidden = [

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { agent, BaseAgent, UnstructuredText } from '../src';
+import { agent, AgentId, BaseAgent, UnstructuredText } from '../src';
 import * as Types from './testTypes';
 import {
   EitherX,
@@ -106,6 +106,19 @@ class SimpleAgent extends BaseAgent {
 
   async fun13(param: ResultTypeNonExact2): Promise<ResultTypeNonExact2> {
     return param;
+  }
+
+  // Overridden methods should be  not be considered as agent methods
+  override loadSnapshot(bytes: Uint8Array): Promise<void> {
+    return super.loadSnapshot(bytes);
+  }
+
+  override saveSnapshot(): Promise<Uint8Array> {
+    return super.saveSnapshot();
+  }
+
+  override getId(): AgentId {
+    return super.getId();
   }
 }
 

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
@@ -109,7 +109,7 @@ class SimpleAgent extends BaseAgent {
   }
 
   // Overridden methods should be  not be considered as agent methods
-  override loadSnapshot(bytes: Uint8Array): Promise<void> {
+  loadSnapshot(bytes: Uint8Array): Promise<void> {
     return super.loadSnapshot(bytes);
   }
 

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
@@ -109,17 +109,20 @@ class SimpleAgent extends BaseAgent {
   }
 
   // Overridden methods should be  not be considered as agent methods
+  // without override keyword
   loadSnapshot(bytes: Uint8Array): Promise<void> {
     return super.loadSnapshot(bytes);
   }
 
+  // With override keyword
   override saveSnapshot(): Promise<Uint8Array> {
     return super.saveSnapshot();
   }
 
-  override getId(): AgentId {
+  // Without override keyword, and existing as an arrow function
+  getId = () => {
     return super.getId();
-  }
+  };
 }
 
 export interface CustomData {

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
@@ -115,7 +115,7 @@ class SimpleAgent extends BaseAgent {
   }
 
   // With override keyword
-  override saveSnapshot(): Promise<Uint8Array> {
+  override async saveSnapshot(): Promise<Uint8Array> {
     return super.saveSnapshot();
   }
 

--- a/golem-ts-agentic/packages/golem-ts-typegen/src/bin/golem-typegen.ts
+++ b/golem-ts-agentic/packages/golem-ts-typegen/src/bin/golem-typegen.ts
@@ -25,7 +25,12 @@ program
   )
   .option(
     "--include-only-public-scope",
-    "Include all types regardless of decorator",
+    "Include only public scope methods and constructors",
+    true,
+  )
+  .option(
+    "--exclude-overridden-methods",
+    "Exclude methods that override parent class methods",
     true,
   )
   .action(
@@ -35,6 +40,7 @@ program
         files: string[];
         includeClassDecorators: string[];
         includeOnlyPublicScope: boolean;
+        excludeOverriddenMethods: boolean;
       },
     ) => {
       console.log(
@@ -54,6 +60,7 @@ program
         sourceFiles: sourceFiles,
         classDecorators: options.includeClassDecorators,
         includeOnlyPublicScope: options.includeOnlyPublicScope,
+        excludeOverriddenMethods: options.excludeOverriddenMethods,
       };
 
       updateMetadataFromSourceFiles(genConfig);

--- a/golem-ts-agentic/packages/golem-ts-typegen/src/index.ts
+++ b/golem-ts-agentic/packages/golem-ts-typegen/src/index.ts
@@ -20,7 +20,8 @@ import {
   SyntaxKind,
   ts,
   Type as TsMorphType,
-  ClassDeclaration, PropertyDeclaration
+  ClassDeclaration,
+  PropertyDeclaration,
 } from "ts-morph";
 import {
   buildJSONFromType,
@@ -574,10 +575,10 @@ export function updateMetadataFromSourceFiles(
         );
 
       for (const publicArrow of publicArrows) {
-
         if (
           classMetadataGenConfig.excludeOverriddenMethods &&
-          (publicArrow.hasOverrideKeyword() || isOverriddenProperty(publicArrow))
+          (publicArrow.hasOverrideKeyword() ||
+            isOverriddenProperty(publicArrow))
         ) {
           continue;
         }

--- a/golem-ts-agentic/packages/golem-ts-typegen/src/index.ts
+++ b/golem-ts-agentic/packages/golem-ts-typegen/src/index.ts
@@ -478,6 +478,7 @@ export type ClassMetadataGenConfig = {
   sourceFiles: SourceFile[];
   classDecorators: string[];
   includeOnlyPublicScope: boolean;
+  excludeOverriddenMethods: boolean;
 };
 
 export function generateClassMetadata(
@@ -530,7 +531,12 @@ export function updateMetadataFromSourceFiles(
         : classDecl.getMethods();
 
       for (const method of publicMethods) {
-        if (method.hasOverrideKeyword()) continue;
+        if (
+          classMetadataGenConfig.excludeOverriddenMethods &&
+          method.hasOverrideKeyword()
+        ) {
+          continue;
+        }
 
         const methodParams = new Map(
           method.getParameters().map((p) => {

--- a/golem-ts-agentic/packages/golem-ts-typegen/src/index.ts
+++ b/golem-ts-agentic/packages/golem-ts-typegen/src/index.ts
@@ -624,7 +624,7 @@ function isOverriddenMethod(method: MethodDeclaration): boolean {
   while (currentBase) {
     const baseMethod = currentBase.getInstanceMethod(methodName);
     if (baseMethod) return true;
-    
+
     currentBase = currentBase.getBaseClass();
   }
 

--- a/golem-ts-agentic/packages/golem-ts-typegen/src/index.ts
+++ b/golem-ts-agentic/packages/golem-ts-typegen/src/index.ts
@@ -531,10 +531,8 @@ export function updateMetadataFromSourceFiles(
         : classDecl.getMethods();
 
       for (const method of publicMethods) {
-        if (
-          classMetadataGenConfig.excludeOverriddenMethods &&
-          method.hasOverrideKeyword()
-        ) {
+
+        if (classMetadataGenConfig.excludeOverriddenMethods && (method.hasOverrideKeyword() || !method.getParent())) {
           continue;
         }
 
@@ -571,6 +569,10 @@ export function updateMetadataFromSourceFiles(
         );
 
       for (const publicArrow of publicArrows) {
+
+        if (classMetadataGenConfig.excludeOverriddenMethods && (publicArrow.hasOverrideKeyword() || !publicArrow.getParent())) {
+          continue;
+        }
         const arrowType = publicArrow.getType();
         const callSignature = arrowType.getCallSignatures()[0];
         if (!callSignature) continue;

--- a/golem-ts-agentic/packages/golem-ts-typegen/tests/setup.ts
+++ b/golem-ts-agentic/packages/golem-ts-typegen/tests/setup.ts
@@ -31,4 +31,5 @@ generateClassMetadata({
   sourceFiles: sourceFiles,
   includeOnlyPublicScope: true,
   classDecorators: [],
+  excludeOverriddenMethods: true,
 });


### PR DESCRIPTION
Thought of adding it straight away.

2 bugs fixed:

* In typescript we can override without override keyword, hence it failed. The tests showed it.
* Not a big thing, yet, overridden arrows (without or with override keyword) were still considered as agent methods. 

```ts
  loadSnapshot = {
    ......
  }
```

Both bugs fixed. The `sampleAgents.ts` in tests has all kinds of overrides thing.

  