### PR TITLE
Expose `WithRemoteMethods`

### DIFF
--- a/golem-ts-agentic/packages/golem-ts-sdk/src/index.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/index.ts
@@ -37,7 +37,7 @@ export * from './newTypes/agentClassName';
 export * from './newTypes/textInput';
 export * from './newTypes/binaryInput';
 
-export { WithRemoteMethods } from './baseAgent'
+export { WithRemoteMethods } from './baseAgent';
 export { AgentClassName } from './newTypes/agentClassName';
 export { TypescriptTypeRegistry } from './typescriptTypeRegistry';
 


### PR DESCRIPTION
## Why?

Previously the `.get` returns `BarAgent`, but now it returns kind of a wrapper called `WithRemoteMethods<BarAgent>` that has extra functionalities  such as trigger and schedule variants for every function. 

But this wrapper type was not explicitly exposed to user (even if they were able to call trigger/schedule).

```ts
class FooAgent extends BaseAgent {
    readonly barAgent: WithRemoteMethods<BarAgent>;
     
     constructor (username: string) {
       this.barAgent = BarAgent.get(username); 
     }
     
     fn foo() {
        this.barAgent.bar();
     }
 }   
 
```