### PR TITLE
Better error handling for errors happening during type resolving via ts-morph

### DIFF
--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/types/AnalysedType.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/types/AnalysedType.ts
@@ -234,7 +234,6 @@ export const option = (name: string| undefined, inner: AnalysedType): AnalysedTy
 
 
 export function fromTsType(tsType: TsType, scope: Option.Option<TypeMappingScope>): Either.Either<AnalysedType, string> {
-
   if (Option.isSome(scope) && (scope.val.scope === "constructor" || scope.val.scope === "method")) {
     if (tsType.optional) {
       return Either.left(`Optional parameters are not supported in ${scope.val.scope}. Parameter \`${scope.val.parameterName}\` is optional. Remove \`?\` and change the type to a union with \`undefined\``);
@@ -601,6 +600,9 @@ export function fromTsTypeInternal(type: TsType, scope: Option.Option<TypeMappin
       } else {
         return Either.left(`Unsupported type \`${customTypeName}\``);
       }
+
+    case "unresolved-type":
+      return Either.left(`Failed to resolve type for \`${type.text}\`: ${type.error}`);
 
     case 'array':
       const name = type.name;

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/values/Value.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/values/Value.ts
@@ -791,6 +791,11 @@ function fromTsValueInternal(
           Option.none(),
         ),
       );
+
+    case 'unresolved-type':
+      return Either.left(
+        `Failed to resolve type for \`${type.text}\`: ${type.error}`,
+      );
   }
 }
 
@@ -1296,6 +1301,9 @@ function matchesType(value: any, type: Type.Type): boolean {
       return false;
 
     case 'others':
+      return false;
+
+    case 'unresolved-type':
       return false;
   }
 }
@@ -1831,6 +1839,11 @@ export function toTsValue(value: Value, type: Type.Type): any {
           Option.some(name ?? 'anonymous'),
           Option.none(),
         ),
+      );
+
+    case 'unresolved-type':
+      throw new Error(
+        `Failed to resolve type for \`${type.text}\`: ${type.error}`,
       );
   }
 }

--- a/golem-ts-agentic/packages/golem-ts-types-core/src/json-to-type.ts
+++ b/golem-ts-agentic/packages/golem-ts-types-core/src/json-to-type.ts
@@ -27,6 +27,15 @@ export function buildTypeFromJSON(json: LiteTypeJSON): Type {
         recursive: json.recursive,
       };
 
+    case 'unresolved-type':
+      return {
+        kind: 'unresolved-type',
+        name: json.name,
+        optional: json.optional,
+        text: json.text,
+        error: json.error,
+      };
+
     case 'boolean':
       return { kind: 'boolean', name: json.name, optional: json.optional };
 

--- a/golem-ts-agentic/packages/golem-ts-types-core/src/type-json.ts
+++ b/golem-ts-agentic/packages/golem-ts-types-core/src/type-json.ts
@@ -77,4 +77,11 @@ export type LiteTypeJSON =
       typeArgs?: LiteTypeJSON[];
       optional: boolean;
     }
-  | { kind: 'others'; name?: string; optional: boolean; recursive: boolean };
+  | { kind: 'others'; name?: string; optional: boolean; recursive: boolean }
+  | {
+      kind: 'unresolved-type';
+      name?: string;
+      optional: boolean;
+      text: string;
+      error: string;
+    };

--- a/golem-ts-agentic/packages/golem-ts-types-core/src/type-lite.ts
+++ b/golem-ts-agentic/packages/golem-ts-types-core/src/type-lite.ts
@@ -38,7 +38,14 @@ export type Type =
   | { kind: 'literal'; name?: string; literalValue?: string; optional: boolean }
   | { kind: 'alias'; name?: string; aliasSymbol: Symbol; optional: boolean }
   | { kind: 'void'; name?: string; optional: boolean }
-  | { kind: 'others'; name?: string; optional: boolean; recursive: boolean };
+  | { kind: 'others'; name?: string; optional: boolean; recursive: boolean }
+  | {
+      kind: 'unresolved-type';
+      name?: string;
+      optional: boolean;
+      text: string;
+      error: string;
+    };
 
 export function getName(t: Type): string | undefined {
   if (t.kind === 'others') return t.name;

--- a/golem-ts-agentic/packages/golem-ts-types-core/src/type-to-json.ts
+++ b/golem-ts-agentic/packages/golem-ts-types-core/src/type-to-json.ts
@@ -176,5 +176,14 @@ export function buildJSONFromType(type: Type.Type): LiteTypeJSON {
 
     case 'boolean':
       return { kind: 'boolean', name: type.name, optional: type.optional };
+
+    case 'unresolved-type':
+      return {
+        kind: 'unresolved-type',
+        name: type.name,
+        optional: type.optional,
+        text: type.text,
+        error: type.error,
+      };
   }
 }


### PR DESCRIPTION
Before:

<img width="753" height="498" alt="image" src="https://github.com/user-attachments/assets/5b6a20ff-171d-4837-8bb3-259e67027918" />

After:

<img width="1863" height="433" alt="image" src="https://github.com/user-attachments/assets/0ccf2a62-bfbe-4ab8-a2af-3ddd69db0018" />
