### PR TITLE
Rename sample agent names

### DIFF
--- a/golem-ts-agentic/package.json
+++ b/golem-ts-agentic/package.json
@@ -22,5 +22,5 @@
         "tslib": "^2.8.1",
         "typescript": "^5.8.3"
     },
-    "packageManager": "pnpm@10.17.0+sha512.fce8a3dd29a4ed2ec566fb53efbb04d8c44a0f05bc6f24a73046910fb9c3ce7afa35a0980500668fa3573345bd644644fa98338fa168235c80f4aa17aa17fbef"
+    "packageManager": "pnpm@10.17.1+sha512.17c560fca4867ae9473a3899ad84a88334914f379be46d455cbf92e5cf4b39d34985d452d2583baf19967fa76cb5c17bc9e245529d0b98745721aa7200ecaf7a"
 }

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/decorator.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/decorator.test.ts
@@ -15,7 +15,7 @@
 import { AgentTypeRegistry } from '../src/internal/registry/agentTypeRegistry';
 import * as Option from '../src/newTypes/option';
 import { expect } from 'vitest';
-import { ComplexAgentClassName, SimpleAgentClassName } from './testUtils';
+import { BarAgentClassName, FooAgentClassName } from './testUtils';
 import { AgentType, DataSchema, ElementSchema } from 'golem:agent/common';
 import * as util from 'node:util';
 
@@ -23,14 +23,14 @@ import * as util from 'node:util';
 // If the sample agents in the set-up changes, this test should fail
 describe('Agent decorator should register the agent class and its methods into AgentTypeRegistry', () => {
   const complexAgent: AgentType = Option.getOrThrowWith(
-    AgentTypeRegistry.lookup(ComplexAgentClassName),
-    () => new Error('ComplexAgent not found in AgentTypeRegistry'),
+    AgentTypeRegistry.lookup(BarAgentClassName),
+    () => new Error('BarAgent not found in AgentTypeRegistry'),
   );
 
   const complexAgentConstructor = complexAgent.constructor;
 
   if (!complexAgentConstructor) {
-    throw new Error('ComplexAgent constructor not found');
+    throw new Error('BarAgent constructor not found');
   }
 
   const complexAgentMethod = complexAgent.methods.find(
@@ -38,7 +38,7 @@ describe('Agent decorator should register the agent class and its methods into A
   );
 
   if (!complexAgentMethod) {
-    throw new Error('fun0 method not found in ComplexAgent');
+    throw new Error('fun0 method not found in BarAgent');
   }
 
   it('should handle UnstructuredText in method params', () => {
@@ -546,8 +546,8 @@ describe('Agent decorator should register the agent class and its methods into A
 
   it('captures all methods and constructor with correct number of parameters', () => {
     const simpleAgent = Option.getOrThrowWith(
-      AgentTypeRegistry.lookup(SimpleAgentClassName),
-      () => new Error('SimpleAgent not found in AgentTypeRegistry'),
+      AgentTypeRegistry.lookup(FooAgentClassName),
+      () => new Error('FooAgent not found in AgentTypeRegistry'),
     );
 
     expect(complexAgent.methods.length).toEqual(23);
@@ -559,8 +559,8 @@ describe('Agent decorator should register the agent class and its methods into A
 
   it('should not capture overridden functions in base agents as agent methods', () => {
     const simpleAgent = Option.getOrThrowWith(
-      AgentTypeRegistry.lookup(SimpleAgentClassName),
-      () => new Error('SimpleAgent not found in AgentTypeRegistry'),
+      AgentTypeRegistry.lookup(FooAgentClassName),
+      () => new Error('FooAgent not found in AgentTypeRegistry'),
     );
 
     const forbidden = [
@@ -586,7 +586,7 @@ function getWitType(dataSchema: DataSchema, parameterName: string) {
 
   if (!witTypeOpt) {
     throw new Error(
-      `Test failed - ${parameterName} is not of component-model type in getWeather function in ${ComplexAgentClassName.value}`,
+      `Test failed - ${parameterName} is not of component-model type in getWeather function in ${BarAgentClassName.value}`,
     );
   }
 

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
@@ -305,10 +305,7 @@ test('BarAgent can be successfully initiated', () => {
           () => new Error('BarAgent not found in AgentInitiatorRegistry'),
         );
 
-        const result = agentInitiator.initiate(
-          BarAgentName.value,
-          dataValue,
-        );
+        const result = agentInitiator.initiate(BarAgentName.value, dataValue);
 
         expect(result.tag).toEqual('ok');
       },
@@ -354,10 +351,7 @@ function initiateFooAgent(
     () => new Error('FooAgent not found in AgentInitiatorRegistry'),
   );
 
-  const result = agentInitiator.initiate(
-    FooAgentName.value,
-    constructorParams,
-  );
+  const result = agentInitiator.initiate(FooAgentName.value, constructorParams);
 
   if (result.tag !== 'ok') {
     throw new Error('Agent initiation failed');

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
@@ -17,13 +17,13 @@ import * as Either from '../src/newTypes/either';
 import { deserializeDataValue } from '../src/decorators';
 import * as Option from '../src/newTypes/option';
 import { AgentInitiatorRegistry } from '../src/internal/registry/agentInitiatorRegistry';
-import { expect, it } from 'vitest';
+import { expect } from 'vitest';
 import * as GolemApiHostModule from 'golem:api/host@1.1.7';
 import {
-  ComplexAgentClassName,
-  ComplexAgentName,
-  SimpleAgentClassName,
-  SimpleAgentName,
+  BarAgentClassName,
+  BarAgentName,
+  FooAgentClassName,
+  FooAgentName,
 } from './testUtils';
 import * as WitValue from '../src/internal/mapping/values/WitValue';
 import * as fc from 'fast-check';
@@ -35,9 +35,6 @@ import {
   objectWithUnionWithUndefined4Arb,
   resultTypeExactArb,
   resultTypeNonExact2Arb,
-  resultTypeNonExact3Arb,
-  resultTypeNonExact4Arb,
-  resultTypeNonExact5Arb,
   resultTypeNonExactArb,
   stringOrNumberOrNull,
   stringOrUndefined,
@@ -54,7 +51,7 @@ import { AgentConstructorParamRegistry } from '../src/internal/registry/agentCon
 import { AgentMethodParamRegistry } from '../src/internal/registry/agentMethodParamRegistry';
 import { AgentMethodRegistry } from '../src/internal/registry/agentMethodRegistry';
 
-test('SimpleAgent can be successfully initiated and all of its methods can be invoked', () => {
+test('An agent can be successfully initiated and all of its methods can be invoked', () => {
   fc.assert(
     fc.property(
       fc.string(),
@@ -89,15 +86,15 @@ test('SimpleAgent can be successfully initiated and all of its methods can be in
         resultTypeNonExact,
         resultTypeNonExact2,
       ) => {
-        overrideSelfMetadataImpl(SimpleAgentName.value);
+        overrideSelfMetadataImpl(FooAgentName.value);
 
-        const typeRegistry = TypeMetadata.get(SimpleAgentClassName.value);
+        const typeRegistry = TypeMetadata.get(FooAgentClassName.value);
 
         if (!typeRegistry) {
-          throw new Error('SimpleAgent type metadata not found');
+          throw new Error('FooAgent type metadata not found');
         }
 
-        const resolvedAgent = initiateSimpleAgent(arbString, typeRegistry);
+        const resolvedAgent = initiateFooAgent(arbString, typeRegistry);
 
         testInvoke(
           'fun1',
@@ -229,36 +226,36 @@ test('SimpleAgent can be successfully initiated and all of its methods can be in
   );
 });
 
-test('ComplexAgent can be successfully initiated', () => {
+test('BarAgent can be successfully initiated', () => {
   fc.assert(
     fc.property(
       interfaceArb,
       fc.oneof(fc.string(), fc.constant(null)),
       fc.oneof(unionArb, fc.constant(null)),
       (interfaceValue, stringValue, unionValue) => {
-        overrideSelfMetadataImpl(ComplexAgentName.value);
+        overrideSelfMetadataImpl(BarAgentName.value);
 
-        const typeRegistry = TypeMetadata.get(ComplexAgentClassName.value);
+        const typeRegistry = TypeMetadata.get(BarAgentClassName.value);
 
         if (!typeRegistry) {
-          throw new Error('ComplexAgent type metadata not found');
+          throw new Error('BarAgent type metadata not found');
         }
 
         // TestInterfaceType
         const arg0 = AgentConstructorParamRegistry.lookupParamType(
-          ComplexAgentClassName,
+          BarAgentClassName,
           typeRegistry.constructorArgs[0].name,
         );
 
         // string | null
         const arg1 = AgentConstructorParamRegistry.lookupParamType(
-          ComplexAgentClassName,
+          BarAgentClassName,
           typeRegistry.constructorArgs[1].name,
         );
 
         // UnionType | null
         const arg2 = AgentConstructorParamRegistry.lookupParamType(
-          ComplexAgentClassName,
+          BarAgentClassName,
           typeRegistry.constructorArgs[2].name,
         );
 
@@ -304,12 +301,12 @@ test('ComplexAgent can be successfully initiated', () => {
         };
 
         const agentInitiator = Option.getOrThrowWith(
-          AgentInitiatorRegistry.lookup(ComplexAgentName),
-          () => new Error('ComplexAgent not found in AgentInitiatorRegistry'),
+          AgentInitiatorRegistry.lookup(BarAgentName),
+          () => new Error('BarAgent not found in AgentInitiatorRegistry'),
         );
 
         const result = agentInitiator.initiate(
-          ComplexAgentName.value,
+          BarAgentName.value,
           dataValue,
         );
 
@@ -319,7 +316,7 @@ test('ComplexAgent can be successfully initiated', () => {
   );
 });
 
-function initiateSimpleAgent(
+function initiateFooAgent(
   constructorParamString: string,
   simpleAgentClassMeta: ClassMetadata,
 ) {
@@ -327,13 +324,13 @@ function initiateSimpleAgent(
 
   const constructorParamAnalysedType =
     AgentConstructorParamRegistry.lookupParamType(
-      SimpleAgentClassName,
+      FooAgentClassName,
       constructorInfo.name,
     );
 
   if (!constructorParamAnalysedType) {
     throw new Error(
-      `Constructor parameter type for SimpleAgent constructor parameter ${constructorInfo.name} not found in metadata.`,
+      `Constructor parameter type for FooAgent constructor parameter ${constructorInfo.name} not found in metadata.`,
     );
   }
 
@@ -353,12 +350,12 @@ function initiateSimpleAgent(
   };
 
   const agentInitiator = Option.getOrThrowWith(
-    AgentInitiatorRegistry.lookup(SimpleAgentName),
-    () => new Error('SimpleAgent not found in AgentInitiatorRegistry'),
+    AgentInitiatorRegistry.lookup(FooAgentName),
+    () => new Error('FooAgent not found in AgentInitiatorRegistry'),
   );
 
   const result = agentInitiator.initiate(
-    SimpleAgentName.value,
+    FooAgentName.value,
     constructorParams,
   );
 
@@ -376,7 +373,7 @@ function testInvoke(
   expectedOutput: any,
 ) {
   const returnTypeInfo = AgentMethodRegistry.lookupReturnType(
-    SimpleAgentClassName,
+    FooAgentClassName,
     methodName,
   );
 
@@ -386,7 +383,7 @@ function testInvoke(
 
   const witValues = parameterAndValue.map(([paramName, value]) => {
     const paramAnalysedType = AgentMethodParamRegistry.lookupParamType(
-      SimpleAgentClassName,
+      FooAgentClassName,
       methodName,
       paramName,
     );

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
@@ -33,7 +33,7 @@ import {
 import { languageCodes, mimeTypes, multimodal } from '../src/decorators';
 
 @agent()
-class SimpleAgent extends BaseAgent {
+class FooAgent extends BaseAgent {
   constructor(readonly input: string) {
     super();
     this.input = input;
@@ -118,7 +118,7 @@ class SimpleAgent extends BaseAgent {
     unstructuredText: UnstructuredText,
     unstructuredBinary: UnstructuredBinary,
   ): Promise<void> {
-    const remoteClient = ComplexAgent.get(
+    const remoteClient = BarAgent.get(
       testInterfaceType,
       optionalStringType,
       optionalUnionType,
@@ -161,7 +161,7 @@ export interface CustomData {
 }
 
 @agent('my-complex-agent')
-class ComplexAgent extends BaseAgent {
+class BarAgent extends BaseAgent {
   constructor(
     readonly testInterfaceType: Types.TestInterfaceType,
     readonly optionalStringType: string | null,

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/testUtils.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/testUtils.ts
@@ -23,77 +23,77 @@ import { AgentMethodParamRegistry } from '../src/internal/registry/agentMethodPa
 import { AgentConstructorParamRegistry } from '../src/internal/registry/agentConstructorParamRegistry';
 import { AgentMethodRegistry } from '../src/internal/registry/agentMethodRegistry';
 
-export const ComplexAgentClassName = new AgentClassName('ComplexAgent');
+export const BarAgentClassName = new AgentClassName('BarAgent');
 
-export const SimpleAgentClassName = new AgentClassName('SimpleAgent');
+export const FooAgentClassName = new AgentClassName('FooAgent');
 
-export const SimpleAgentName =
-  AgentTypeName.fromAgentClassName(SimpleAgentClassName);
+export const FooAgentName =
+  AgentTypeName.fromAgentClassName(FooAgentClassName);
 
-export const ComplexAgentName = AgentTypeName.fromString('my-complex-agent');
+export const BarAgentName = AgentTypeName.fromString('my-complex-agent');
 
 export function getAll() {
   return TypeMetadata.getAll();
 }
 
 export function getTestInterfaceType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('TestInterfaceType');
+  return fetchTypeFromBarAgent('TestInterfaceType');
 }
 
 export function getTestMapType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('MapType');
+  return fetchTypeFromBarAgent('MapType');
 }
 
 export function getTestObjectType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('ObjectType');
+  return fetchTypeFromBarAgent('ObjectType');
 }
 
 export function getTestListOfObjectType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('ListComplexType');
+  return fetchTypeFromBarAgent('ListComplexType');
 }
 
 export function getUnionType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('UnionType');
+  return fetchTypeFromBarAgent('UnionType');
 }
 
 export function getResultTypeExact(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('ResultTypeExactBoth');
+  return fetchTypeFromBarAgent('ResultTypeExactBoth');
 }
 
 export function getUnionComplexType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('UnionComplexType');
+  return fetchTypeFromBarAgent('UnionComplexType');
 }
 
 export function getTupleType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('TupleType');
+  return fetchTypeFromBarAgent('TupleType');
 }
 
 export function getTupleComplexType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('TupleComplexType');
+  return fetchTypeFromBarAgent('TupleComplexType');
 }
 
 export function getBooleanType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('boolean');
+  return fetchTypeFromBarAgent('boolean');
 }
 
 export function getStringType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('string');
+  return fetchTypeFromBarAgent('string');
 }
 
 export function getNumberType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('number');
+  return fetchTypeFromBarAgent('number');
 }
 
 export function getPromiseType(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('PromiseType');
+  return fetchTypeFromBarAgent('PromiseType');
 }
 
 export function getUnionWithLiterals(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('UnionWithLiterals');
+  return fetchTypeFromBarAgent('UnionWithLiterals');
 }
 
 export function getUnionWithOnlyLiterals(): [AnalysedType, Type.Type] {
-  return fetchTypeFromComplexAgent('UnionWithOnlyLiterals');
+  return fetchTypeFromBarAgent('UnionWithOnlyLiterals');
 }
 
 export function getRecordFieldsFromAnalysedType(
@@ -102,13 +102,13 @@ export function getRecordFieldsFromAnalysedType(
   return analysedType.kind === 'record' ? analysedType.value.fields : undefined;
 }
 
-function fetchTypeFromComplexAgent(
+function fetchTypeFromBarAgent(
   typeNameInTestData: string,
 ): [AnalysedType, Type.Type] {
-  const complexAgentMetadata = TypeMetadata.get('ComplexAgent');
+  const complexAgentMetadata = TypeMetadata.get('BarAgent');
 
   if (!complexAgentMetadata) {
-    throw new Error('Class metadata for ComplexAgent not found');
+    throw new Error('Class metadata for BarAgent not found');
   }
 
   const constructorArg = complexAgentMetadata.constructorArgs.find((arg) => {
@@ -118,7 +118,7 @@ function fetchTypeFromComplexAgent(
 
   if (constructorArg) {
     const analysedType = AgentConstructorParamRegistry.lookupParamType(
-      ComplexAgentClassName,
+      BarAgentClassName,
       constructorArg.name,
     );
 
@@ -133,7 +133,7 @@ function fetchTypeFromComplexAgent(
       Type.getTypeName(method.returnType) === typeNameInTestData
     ) {
       const analysedType = AgentMethodRegistry.lookupReturnType(
-        ComplexAgentClassName,
+        BarAgentClassName,
         name,
       );
 
@@ -147,7 +147,7 @@ function fetchTypeFromComplexAgent(
 
     if (param) {
       const analysedType = AgentMethodParamRegistry.lookupParamType(
-        ComplexAgentClassName,
+        BarAgentClassName,
         name,
         param[0],
       );

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/testUtils.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/testUtils.ts
@@ -27,8 +27,7 @@ export const BarAgentClassName = new AgentClassName('BarAgent');
 
 export const FooAgentClassName = new AgentClassName('FooAgent');
 
-export const FooAgentName =
-  AgentTypeName.fromAgentClassName(FooAgentClassName);
+export const FooAgentName = AgentTypeName.fromAgentClassName(FooAgentClassName);
 
 export const BarAgentName = AgentTypeName.fromString('my-complex-agent');
 

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/value.mapping.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/value.mapping.test.ts
@@ -26,7 +26,7 @@ import {
   getUnionWithOnlyLiterals,
   getUnionWithLiterals,
   getResultTypeExact,
-  ComplexAgentName,
+  BarAgentName,
 } from './testUtils';
 
 import { TestInterfaceType } from './testTypes';


### PR DESCRIPTION
To avoid confusion of the names such as `SimpleAgent`, `ComplexAgent` in tests. The names were once true, and now nothing is complex or simple over the other. 