### PR TITLE
Handle invalid agent declaration,  update API docs, and add tests

### DIFF
--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleInvalidAgents.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleInvalidAgents.ts
@@ -16,9 +16,9 @@ import { agent, BaseAgent } from '../src';
 import * as Types from './testTypes';
 import { RecursiveType } from './testTypes';
 
-// This is a set of invalid agents
-// Note that this file is not "imported" anywhere like `sampleAgents.ts`
-// as decorators will fail and none of the tests will run
+// !!! This is a set of invalid agents
+// Note that this file is not (and shouldn't be) "imported" anywhere else directly
+// as decorators will fail and none of the tests will run.
 
 @agent()
 class InvalidAgent extends BaseAgent {


### PR DESCRIPTION
### Undecorated agents
```ts
export class UndecoratedAgent extends BaseAgent {
  async foo(): Promise<AgentId> {
    return this.getId();
  }
}

```

```ts

 // Remote client creation failed: `UndecoratedAgent` must be decorated with @agent()
UndecoratedAgent.get()

// AgentId is not available for `UndecoratedAgent`. Ensure the class is decorated with @agent()
new UndecoratedAgent().getAgentId() 

// etc
```

### Agents not extending BaseAgent

```ts
 @agent()
    class AgentWithoutBaseAgent {
      async foo(): Promise<void> {
        return;
      }
    }
```


```
Invalid agent declaration: `AgentWithoutBaseAgent` must extend `BaseAgent` to be decorated with @agent()
```


