### PR TITLE
Support void everywhere

### DIFF
--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/types/AnalysedType.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/types/AnalysedType.ts
@@ -329,13 +329,13 @@ export function fromTsTypeInternal(type: TsType, scope: Option.Option<TypeMappin
       return Either.right(u64(true))
 
     case "null":
-      return Either.left("Unsupported type `null` in " + (scopeName ? `${scopeName}` : "") + " " + (Option.isSome(parameterInScope) ? `for parameter \`${parameterInScope.val}\`` : ""));
+      return Either.right(tuple(undefined, 'undefined', []))
 
     case "undefined":
-      return Either.left("Unsupported type `undefined` in " + (scopeName ? `${scopeName}` : "") + " " + (Option.isSome(parameterInScope) ? `for parameter \`${parameterInScope.val}\`` : ""));
+      return Either.right(tuple(undefined, 'undefined', []))
 
     case "void":
-      return Either.left("Unsupported type `void` in " + (scopeName ? `${scopeName}` : "") + " " + (Option.isSome(parameterInScope) ? `for parameter \`${parameterInScope.val}\`` : ""));
+      return Either.right(tuple(undefined, 'undefined', []))
 
     case "tuple":
       const tupleElems = Either.all(type.elements.map(el => fromTsTypeInternal(el, Option.none())));

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/schema.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/schema.ts
@@ -393,14 +393,6 @@ export function buildOutputSchema(
     ]);
   }
 
-  const undefinedSchema = handleUndefinedReturnType(returnType);
-  if (Option.isSome(undefinedSchema)) {
-    return Either.right([
-      { tag: 'analysed', val: tuple(undefined, 'undefined', []) },
-      undefinedSchema.val,
-    ]);
-  }
-
   const unstructuredText = handleUnstructuredCase(
     returnType,
     'UnstructuredText',
@@ -747,37 +739,6 @@ function convertToElementSchema(
       val: witType,
     };
   });
-}
-
-function handleUndefinedReturnType(
-  returnType: Type.Type,
-): Option.Option<DataSchema> {
-  switch (returnType.kind) {
-    case 'null':
-      return Option.some({
-        tag: 'tuple',
-        val: [],
-      });
-
-    case 'undefined':
-      return Option.some({
-        tag: 'tuple',
-        val: [],
-      });
-
-    case 'void':
-      return Option.some({
-        tag: 'tuple',
-        val: [],
-      });
-
-    case 'promise':
-      const elementType = returnType.element;
-      return handleUndefinedReturnType(elementType);
-
-    default:
-      return Option.none();
-  }
 }
 
 function getBinaryDescriptor(

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/decorator.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/decorator.test.ts
@@ -703,7 +703,7 @@ describe('Agent decorator should register the agent class and its methods into A
     expect(complexAgent.methods.length).toEqual(24);
     expect(complexAgent.constructor.inputSchema.val.length).toEqual(6);
     expect(complexAgent.typeName).toEqual('my-complex-agent');
-    expect(simpleAgent.methods.length).toEqual(31);
+    expect(simpleAgent.methods.length).toEqual(32);
     expect(simpleAgent.constructor.inputSchema.val.length).toEqual(1);
   });
 

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/invalid.agents.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/invalid.agents.test.ts
@@ -115,18 +115,6 @@ describe('Invalid types in agents', () => {
       'Unsupported type `BigInt`, use `bigint` instead',
     );
 
-    expect(nullType.val).toBe(
-      'Unsupported type `null` in fun1 for parameter `nullParam`',
-    );
-
-    expect(undefinedType.val).toBe(
-      'Unsupported type `undefined` in fun1 for parameter `undefined`',
-    );
-
-    expect(voidType.val).toBe(
-      'Unsupported type `void` in fun1 for parameter `voidParam`',
-    );
-
     expect(unionWithKeyWord.val).toBe(
       '`ok` is a reserved keyword. The following keywords cannot be used as literals: ok, err, none, some',
     );

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
@@ -443,6 +443,32 @@ test('Invoke function that takes and returns inbuilt result type', () => {
   );
 });
 
+test('Invoke function that takes and returns result of void', () => {
+  overrideSelfMetadataImpl(FooAgentClassName);
+  const classMetadata = TypeMetadata.get(FooAgentClassName.value);
+  if (!classMetadata) {
+    throw new Error('FooAgent type metadata not found');
+  }
+
+  const resolvedAgent = initiateFooAgent('foo', classMetadata);
+
+  testInvoke(
+    'fun32',
+    [['param', Result.ok(undefined)]],
+    resolvedAgent,
+    Result.ok(undefined),
+    false,
+  );
+
+  testInvoke(
+    'fun32',
+    [['param', Result.err('message')]],
+    resolvedAgent,
+    Result.err('message'),
+    false,
+  );
+});
+
 test('Invoke function that takes and returns multimodal types', () => {
   overrideSelfMetadataImpl(FooAgentClassName);
 

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
@@ -226,6 +226,10 @@ class FooAgent extends BaseAgent {
     return param;
   }
 
+  async fun32(param: Result<void, string>): Promise<Result<void, string>> {
+    return param;
+  }
+
   // Overridden methods should be  not be considered as agent methods
   // without override keyword
   loadSnapshot(bytes: Uint8Array): Promise<void> {


### PR DESCRIPTION
We supported only at the return type position - with special handling such as `Promise<void>`

Meaning void works as such (here is a an example that uses the last released agentic)

```ts
@agent()
class FooAgent extends BaseAgent {
    private rpcAgent: WithRemoteMethods<BarAgent>;

    constructor() {
        super()
        this.rpcAgent =  BarAgent.get();
    }

    async doNothing(): Promise<void> {
        return await this.rpcAgent.doNothing();
    }
}

@agent()
class BarAgent extends BaseAgent {
    async doNothing(): Promise<void>  {
        return undefined

    }
}

```

<img width="604" height="294" alt="image" src="https://github.com/user-attachments/assets/ccbadf95-5c9f-4313-b1a6-023e77a82df2" />


 However, in rest of the places it was not supported.  I don't see the reason why it has to be this way anymore.
 
 In this PR, I removed this "special" handling to make sure  `void` everywhere such that, for example, `Result<void, string>` automatically works
