### PR TITLE
support void in standard result type, and fix RPC 

### DIFF
--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/types/AnalysedType.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/types/AnalysedType.ts
@@ -873,6 +873,25 @@ export function getInbuiltResultType(
       const okType = typeParams[0];
       const errType = typeParams[1];
 
+      const okIsVoid = isVoidType(okType);
+      const errIsVoid = isVoidType(errType);
+
+      if (okIsVoid && errIsVoid) {
+        return Either.right(result(undefined, { tag: 'inbuilt', okEmptyType: 'void', errEmptyType: 'void' }, undefined, undefined));
+      }
+
+      if (okIsVoid) {
+        return Either.map(fromTsTypeInternal(errType, Option.none()), (err) =>
+          result(undefined, { tag: 'inbuilt', okEmptyType: 'void', errEmptyType: undefined }, undefined, err)
+        );
+      }
+
+      if (errIsVoid) {
+        return Either.map(fromTsTypeInternal(okType, Option.none()), (ok) =>
+          result(undefined, { tag: 'inbuilt', okEmptyType: undefined, errEmptyType: 'void' }, ok, undefined)
+        );
+      }
+
       const okAnalysed = fromTsTypeInternal(okType, Option.none());
       const errAnalysed = fromTsTypeInternal(errType, Option.none());
 

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/values/serializer.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/mapping/values/serializer.ts
@@ -481,10 +481,7 @@ export function serializeDefaultTsValue(
                 return Either.right({
                   kind: 'result',
                   value: {
-                    ok: {
-                      kind: 'tuple',
-                      value: [],
-                    },
+                    ok: undefined,
                   },
                 });
               }
@@ -511,10 +508,7 @@ export function serializeDefaultTsValue(
                 return Either.right({
                   kind: 'result',
                   value: {
-                    err: {
-                      kind: 'tuple',
-                      value: [],
-                    },
+                    err: undefined,
                   },
                 });
               }

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/decorator.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/decorator.test.ts
@@ -762,7 +762,7 @@ describe('Agent decorator should register the agent class and its methods into A
     expect(complexAgent.methods.length).toEqual(25);
     expect(complexAgent.constructor.inputSchema.val.length).toEqual(6);
     expect(complexAgent.typeName).toEqual('my-complex-agent');
-    expect(simpleAgent.methods.length).toEqual(43);
+    expect(simpleAgent.methods.length).toEqual(44);
     expect(simpleAgent.constructor.inputSchema.val.length).toEqual(1);
   });
 

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
@@ -487,6 +487,32 @@ test('Invoke function that takes and returns inbuilt result type with void', () 
   const resolvedAgent = initiateFooAgent('foo', classMetadata);
 
   testInvoke(
+    'fun44',
+    [['param', Result.ok(undefined)]],
+    resolvedAgent,
+    Result.ok(undefined),
+    false,
+  );
+
+  testInvoke(
+    'fun44',
+    [['param', Result.err(undefined)]],
+    resolvedAgent,
+    Result.err(undefined),
+    false,
+  );
+});
+
+test('Invoke function that takes and returns inbuilt result type with undefined', () => {
+  overrideSelfAgentId(new AgentId('foo-agent()'));
+  const classMetadata = TypeMetadata.get(FooAgentClassName.value);
+  if (!classMetadata) {
+    throw new Error('FooAgent type metadata not found');
+  }
+
+  const resolvedAgent = initiateFooAgent('foo', classMetadata);
+
+  testInvoke(
     'fun32',
     [['param', 'foo']],
     resolvedAgent,

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/sampleAgents.ts
@@ -284,6 +284,10 @@ export class FooAgent extends BaseAgent {
     return param;
   }
 
+  async fun44(param: Result<void, void>): Promise<Result<void, void>> {
+    return param;
+  }
+
   // Overridden methods should be  not be considered as agent methods
   // without override keyword
   loadSnapshot(bytes: Uint8Array): Promise<void> {


### PR DESCRIPTION
Fixes #181 


SDK standard result types had two issues: One is void was not supported similar to the [bug](https://github.com/golemcloud/golem-agentic/pull/216#issue-3736765085) in user defined result type. Second is, RPC never worked even after making it supported in type mappings. Both are fixed

```
Stderr:

thread '<unnamed>' (1) panicked at src/internal.rs:276:41:
Exception during awaiting call result for guest.invoke:
JavaScript error: Failed to invoke corge in agent bar-agent("foos")
Stack:
    at invokeAndAwait (@golemcloud/golem-ts-sdk:5824:27)
```


```ts

import {
    BaseAgent,
    Result,
    agent,
    prompt,
    description, Client,
} from '@golemcloud/golem-ts-sdk';

@agent()
class CounterAgent extends BaseAgent {
    private readonly name: string;
    private readonly client: Client<BarAgent>;

    constructor(name: string) {
        super()
        this.name = name;
        this.client = BarAgent.get(name);
    }

    async foo(input: Result<number, void>): Promise<Result<number, void>> {
        return await this.client.qux(input);
    }

    async bar(input: Result<void, number>): Promise<Result<void, number>> {
        return await this.client.corge(input);
    }

    async baz(input: Result<void, void>): Promise<Result<void, void>> {
        return await this.client.grault(input);
    }
}


@agent()
class BarAgent extends BaseAgent {
    private readonly name: string;
    private value: number = 0;

    constructor(name: string) {
        super()
        this.name = name;
    }

    async qux(input: Result<number, void>): Promise<Result<number, void>> {
        return input
    }

    async corge(input: Result<void, number>): Promise<Result<void, number>> {
        return input
    }

    async grault(input: Result<void, void>): Promise<Result<void, void>> {
        return input
    }

}


```


<img width="923" height="1004" alt="image" src="https://github.com/user-attachments/assets/d541d7f6-5c7e-431e-abd2-bc2c456ff49e" />



Once the new ts-sdk is released, will add these tests along with the ones in https://github.com/golemcloud/golem-agentic/pull/216#issue-3736765085

