### PR TITLE
Fix multimodal types

### DIFF
--- a/golem-ts-agentic/packages/golem-ts-sdk/src/decorators.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/decorators.ts
@@ -313,6 +313,8 @@ export function agent(options?: AgentDecoratorOptions) {
           };
         }
 
+        instance.getId = () => agentId;
+
         const resolvedAgent = new ResolvedAgent(
           instance,
           agentClassName,

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/clientGeneration.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/clientGeneration.ts
@@ -749,7 +749,8 @@ function convertValueToTextReference(value: Value.Value): TextReference {
             case 'record':
               const record = inlineValue.value;
               const data = record[0];
-              const languageCodeField = record.length > 1 ? record[1] : undefined;
+              const languageCodeField =
+                record.length > 1 ? record[1] : undefined;
 
               switch (data.kind) {
                 case 'string':
@@ -790,10 +791,10 @@ function convertValueToTextReference(value: Value.Value): TextReference {
                             },
                           };
 
-                          default:
-                            throw new Error(
-                              `Invalid inline text language code option type: expected string, found ${JSON.stringify(langCodeOpt)}`,
-                              );
+                        default:
+                          throw new Error(
+                            `Invalid inline text language code option type: expected string, found ${JSON.stringify(langCodeOpt)}`,
+                          );
                       }
 
                     default:

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/clientGeneration.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/clientGeneration.ts
@@ -444,7 +444,8 @@ class WasmRpcProxyHandler implements ProxyHandler<any> {
         rpcResult.tag === 'err'
           ? (() => {
               throw new Error(
-                'Remote agent returned error result: ' + JSON.stringify(rpcResult.val),
+                'Remote agent returned error result: ' +
+                  JSON.stringify(rpcResult.val),
               );
             })()
           : rpcResult.val;

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/clientGeneration.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/clientGeneration.ts
@@ -590,7 +590,7 @@ function deserializeRpcResult(
       )[0];
 
     case 'multimodal':
-      const multimodalParamInfo: ParameterDetail[] = typeInfoInternal.types;
+      const multimodalParamsInfo: ParameterDetail[] = typeInfoInternal.types;
 
       switch (rpcResult.kind) {
         // A multimodal value is always a list
@@ -602,7 +602,7 @@ function deserializeRpcResult(
               switch (value.kind) {
                 case 'variant':
                   const caseIdx = value.caseIdx;
-                  const paramDetail = multimodalParamInfo[caseIdx];
+                  const paramDetail = multimodalParamsInfo[caseIdx];
                   const caseValue = value.caseValue;
 
                   if (!caseValue) {
@@ -632,7 +632,12 @@ function deserializeRpcResult(
           };
 
           return Either.getOrThrowWith(
-            deserializeDataValue(dataValue, multimodalParamInfo),
+            deserializeDataValue(dataValue, [
+              {
+                name: 'return-value',
+                type: typeInfoInternal,
+              },
+            ]),
             (err) =>
               new Error(
                 `Failed to deserialize multimodal return value: ${err}`,

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/schema.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/schema.ts
@@ -1038,7 +1038,8 @@ export function getMimeTypes(type: Type.Type): Either.Either<string[], string> {
   ) {
     const parameterTypes: Type.Type[] = promiseUnwrappedType.typeParams ?? [];
 
-    if (parameterTypes.length !== 1) {
+    if (parameterTypes.length === 0) {
+      console.log("No parameter types found for UnstructuredBinary");
       return Either.right([]);
     }
 
@@ -1059,8 +1060,10 @@ export function getMimeTypes(type: Type.Type): Either.Either<string[], string> {
           }
         }),
       );
+    } else if (paramType.kind === 'string') {
+      return Either.right([]);
     } else {
-      return Either.left('unknown parameter type for UnstructuredBinary');
+      return Either.left('unknown parameter type for UnstructuredBinary' + paramType.kind);
     }
   }
 

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/schema.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/schema.ts
@@ -1039,7 +1039,6 @@ export function getMimeTypes(type: Type.Type): Either.Either<string[], string> {
     const parameterTypes: Type.Type[] = promiseUnwrappedType.typeParams ?? [];
 
     if (parameterTypes.length === 0) {
-      console.log("No parameter types found for UnstructuredBinary");
       return Either.right([]);
     }
 
@@ -1063,7 +1062,9 @@ export function getMimeTypes(type: Type.Type): Either.Either<string[], string> {
     } else if (paramType.kind === 'string') {
       return Either.right([]);
     } else {
-      return Either.left('unknown parameter type for UnstructuredBinary' + paramType.kind);
+      return Either.left(
+        'unknown parameter type for UnstructuredBinary' + paramType.kind,
+      );
     }
   }
 

--- a/golem-ts-agentic/packages/golem-ts-sdk/src/internal/schema.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/src/internal/schema.ts
@@ -1036,16 +1036,18 @@ export function getMimeTypes(type: Type.Type): Either.Either<string[], string> {
     promiseUnwrappedType.name === 'UnstructuredBinary' &&
     promiseUnwrappedType.kind === 'union'
   ) {
-    const parameterTypes: Type.Type[] = promiseUnwrappedType.typeParams ?? [];
+    const unstructuredBinaryTypeParameters: Type.Type[] =
+      promiseUnwrappedType.typeParams ?? [];
 
-    if (parameterTypes.length === 0) {
+    if (unstructuredBinaryTypeParameters.length === 0) {
       return Either.right([]);
     }
 
-    const paramType: Type.Type = parameterTypes[0];
+    const unstructuredBinaryTypeParameter: Type.Type =
+      unstructuredBinaryTypeParameters[0];
 
-    if (paramType.kind === 'tuple') {
-      const elem = paramType.elements;
+    if (unstructuredBinaryTypeParameter.kind === 'tuple') {
+      const elem = unstructuredBinaryTypeParameter.elements;
 
       return Either.all(
         elem.map((v) => {
@@ -1059,11 +1061,14 @@ export function getMimeTypes(type: Type.Type): Either.Either<string[], string> {
           }
         }),
       );
-    } else if (paramType.kind === 'string') {
+    } else if (unstructuredBinaryTypeParameter.kind === 'string') {
+      // If the type parameter is of `type` string, it implies, we return an empty set of mime-types,
+      // and the absence of restrictions would result in allowing any mime type
       return Either.right([]);
     } else {
       return Either.left(
-        'unknown parameter type for UnstructuredBinary' + paramType.kind,
+        'unknown parameter type for UnstructuredBinary' +
+          unstructuredBinaryTypeParameter.kind,
       );
     }
   }

--- a/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
+++ b/golem-ts-agentic/packages/golem-ts-sdk/tests/invoke.test.ts
@@ -561,7 +561,7 @@ test('Invoke function that takes and returns inbuilt result type with undefined'
   );
 });
 
-test('Invoke function that takes and returns multimodal', () => {
+test('Invoke function that takes and returns multimodal default', () => {
   overrideSelfAgentId(new AgentId('foo-agent()'));
 
   const classMetadata = TypeMetadata.get(FooAgentClassName.value);


### PR DESCRIPTION
Fix #2325 and some others

There are multiple issues, 1 is in golem which will be fixed while updating TS SDK


1. constructor parameter in RPC calls not working (which is basically #2325) `multimodal values not supported during RPC call`

2. `getId` was not working. This was giving `agent not initialized` error which was confusing. Anyway fixed.

3. Multimodal when part of return type wasn't working 

4. When language code was empty, it threw an error  `Invalid inline text language code type: expected string`

5. There is a bug back in golem for `makeAgentId` when data-value (input) is multimodal with some `length mismatch` error.  Small fix which is in fix_multimodal_agent branch, and will be raised  as PR when updating the TS SDK branch

For the following code, which takes `Multimodal` everywhere (methods, constructors, RPC), the fixes worked

```rust
import {
    BaseAgent,
    Result,
    agent,
    prompt,
    description, Client, Multimodal, MultimodalAdvanced,
} from '@golemcloud/golem-ts-sdk';

@agent()
class CounterAgent extends BaseAgent {
   // This wasn't working
    constructor(readonly input: Multimodal) {
        super()
    }
   
    // This wasn't working
    async get_agent_id(): Promise<string> {
        return this.getId().value
    }

    async foo(input: Multimodal): Promise<Multimodal> {
    
        const client = BarAgent.get(input); // input to RPC was not working
        return await client.foo(input);
    }
}


@agent()
class BarAgent extends BaseAgent {
    constructor(readonly input: Multimodal) {
        super()
    }

    async foo(input: Multimodal): Promise<Multimodal> { // Return type was not working
        return input
    }


}
```


<img width="1222" height="179" alt="image" src="https://github.com/user-attachments/assets/ea71c669-e0bf-4c23-9526-18066bc7e013" />

